### PR TITLE
Fix #40: allow the Operator to start on Openshift 3.x

### DIFF
--- a/pkg/framework/controller_watcher.go
+++ b/pkg/framework/controller_watcher.go
@@ -95,7 +95,7 @@ func (c *controllerWatcher) Watch(watchedObjects ...WatchedObjects) (err error) 
 		if object.AddToScheme == nil {
 			desiredObjects = append(desiredObjects, object)
 		} else {
-			if _, found := serverGroupMap[object.GroupVersion.Group][object.GroupVersion.Version]; found {
+			if _, found := serverGroupMap[object.GroupVersion.String()]; found {
 				addToScheme = append(addToScheme, object.AddToScheme)
 				desiredObjects = append(desiredObjects, object)
 				delete(c.groupsNotWatched, object.GroupVersion.Group)
@@ -133,19 +133,18 @@ func (c *controllerWatcher) Watch(watchedObjects ...WatchedObjects) (err error) 
 	return
 }
 
-func (c *controllerWatcher) getServerGroupMap() (map[string]map[string]bool, error) {
+func (c *controllerWatcher) getServerGroupMap() (map[string]bool, error) {
 	serverGroups, err := c.discoverClient.ServerGroups()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't fetch server groups list: %v", err)
 	}
 
-	serverGroupMap := map[string]map[string]bool{}
+	serverGroupMap := make(map[string]bool)
 	for _, serverGroup := range serverGroups.Groups {
-		versions := make(map[string]bool)
 		for _, version := range serverGroup.Versions {
-			versions[version.Version] = true
+			key := fmt.Sprintf("%s/%s", serverGroup.Name, version.Version)
+			serverGroupMap[key] = true
 		}
-		serverGroupMap[serverGroup.Name] = versions
 	}
 	return serverGroupMap, nil
 }

--- a/pkg/framework/controller_watcher.go
+++ b/pkg/framework/controller_watcher.go
@@ -18,12 +18,11 @@
 package framework
 
 import (
-	"strings"
-
+	"fmt"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
-	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -83,7 +82,7 @@ func (c *controllerWatcher) IsGroupWatched(group string) bool {
 }
 
 func (c *controllerWatcher) Watch(watchedObjects ...WatchedObjects) (err error) {
-	serverGroups, err := c.discoverClient.ServerGroups()
+	serverGroupMap, err := c.getServerGroupMap()
 	if err != nil {
 		return
 	}
@@ -96,17 +95,11 @@ func (c *controllerWatcher) Watch(watchedObjects ...WatchedObjects) (err error) 
 		if object.AddToScheme == nil {
 			desiredObjects = append(desiredObjects, object)
 		} else {
-			found := false
-			for _, serverGroup := range serverGroups.Groups {
-				if strings.Contains(serverGroup.Name, object.GroupVersion.Group) {
-					addToScheme = append(addToScheme, object.AddToScheme)
-					desiredObjects = append(desiredObjects, object)
-					found = true
-					delete(c.groupsNotWatched, object.GroupVersion.Group)
-					break
-				}
-			}
-			if !found {
+			if _, found := serverGroupMap[object.GroupVersion.Group][object.GroupVersion.Version]; found {
+				addToScheme = append(addToScheme, object.AddToScheme)
+				desiredObjects = append(desiredObjects, object)
+				delete(c.groupsNotWatched, object.GroupVersion.Group)
+			} else {
 				c.groupsNotWatched[object.GroupVersion.Group] = true
 				log.Warnf("Impossible to register GroupVersion %s. CRD not installed in the cluster, controller might not behave as expected", object.GroupVersion)
 			}
@@ -138,4 +131,21 @@ func (c *controllerWatcher) Watch(watchedObjects ...WatchedObjects) (err error) 
 	}
 
 	return
+}
+
+func (c *controllerWatcher) getServerGroupMap() (map[string]map[string]bool, error) {
+	serverGroups, err := c.discoverClient.ServerGroups()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't fetch server groups list: %v", err)
+	}
+
+	serverGroupMap := map[string]map[string]bool{}
+	for _, serverGroup := range serverGroups.Groups {
+		versions := make(map[string]bool)
+		for _, version := range serverGroup.Versions {
+			versions[version.Version] = true
+		}
+		serverGroupMap[serverGroup.Name] = versions
+	}
+	return serverGroupMap, nil
 }


### PR DESCRIPTION
Use a map indexed by the server group with another map as value indexed
by the versions of that group which are available in this cluster. This
allows for O(n) time complexity when checking if the desired objects are
available.