### PR TITLE
Renaming Package to not clash with certified operators

### DIFF
--- a/deploy/olm-catalog/nexus-operator/nexus-operator-operatorsource.yaml
+++ b/deploy/olm-catalog/nexus-operator/nexus-operator-operatorsource.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorSource
 metadata:
-  name: nexus-operator-hub
+  name: nexus-operator-m88i
   namespace: openshift-marketplace
 spec:
   type: appregistry

--- a/deploy/olm-catalog/nexus-operator/nexus-operator-operatorsource.yaml
+++ b/deploy/olm-catalog/nexus-operator/nexus-operator-operatorsource.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorSource
 metadata:
-  name: nexus-operator-m88i
+  name: nexus-operator-hub
   namespace: openshift-marketplace
 spec:
   type: appregistry

--- a/deploy/olm-catalog/nexus-operator/nexus-operator.package.yaml
+++ b/deploy/olm-catalog/nexus-operator/nexus-operator.package.yaml
@@ -2,4 +2,4 @@ channels:
 - currentCSV: nexus-operator.v0.2.0
   name: alpha
 defaultChannel: alpha
-packageName: nexus-operator-m88i
+packageName: nexus-operator-hub

--- a/deploy/olm-catalog/nexus-operator/nexus-operator.package.yaml
+++ b/deploy/olm-catalog/nexus-operator/nexus-operator.package.yaml
@@ -2,4 +2,4 @@ channels:
 - currentCSV: nexus-operator.v0.2.0
   name: alpha
 defaultChannel: alpha
-packageName: nexus-operator
+packageName: nexus-operator-m88i


### PR DESCRIPTION
Looks like our operator clashes with a certified one:

```
===== Test: operator-packagename-uniqueness =====

Package nexus-operator already exists but it is attached to another source!

existing source == certified-operators
expected source == community-operators

Package nexus-operator already exists but it has a different association!

existing association == ospid-110bf87b-2bc7-4fbc-9763-055e3cca729a
expected association == nexus-operator



---------------------------------
---------------------------------
Package Name Uniqueness Overview:
---------------------------------
---------------------------------

The use of Operators requires that all packageNames are *globally unique* across all quay.io namespaces.
This test effectively 'claims' a package name by locking it to a specific operator / source.

Source
------

Source is defined as where an operator is coming from:

All Operators come one of 4 sources:
- Upstream
- Community
- Certified
- Redhat

Association
-----------

Association is defined as an item from the source that can used
to align the packageName to.
 
All Operators have an association within their source that helps identify them.

For Upstream and Community operators, the association is derived from the operator's folder name within the GitHub repo.
For Certified operators, the association is derived from the projectID from RHConnect.
For RedHat operators, the association is derived from the Brew Package Name

Details for this Operator
-------------------------

This operator-under-test has a package name of nexus-operator

Its source is community-operators with an association of nexus-operator
```

See: https://github.com/operator-framework/community-operators/pull/1703