### PR TITLE
update roles.yaml

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -17,6 +17,7 @@ rules:
       - secrets
       - replicationcontrollers
       - podtemplates
+      - serviceaccounts
     verbs:
       - create
       - delete


### PR DESCRIPTION
As a fix for #41 the operator now creates service accounts based on parameters or Custom Resource names. For that behaviour to be correct, the roles have to include the required permissions.