### PR TITLE
Fix Ingress comparison

### DIFF
--- a/pkg/controller/nexus/resource/comparator.go
+++ b/pkg/controller/nexus/resource/comparator.go
@@ -20,11 +20,7 @@ package resource
 import (
 	"github.com/RHsyseng/operator-utils/pkg/resource"
 	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/rbac"
-	routev1 "github.com/openshift/api/route/v1"
-	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"reflect"
 )
 
@@ -33,26 +29,15 @@ import (
 func GetComparator() compare.MapComparator {
 	resourceComparator := compare.DefaultComparator()
 
-	pvcType := reflect.TypeOf(v1.PersistentVolumeClaim{})
-	svcType := reflect.TypeOf(v1.Service{})
-	routeType := reflect.TypeOf(routev1.Route{})
-	deploymentType := reflect.TypeOf(appsv1.Deployment{})
-	ingressType := reflect.TypeOf(v1beta1.Ingress{})
-	svcAccntType := reflect.TypeOf(v1.ServiceAccount{})
-
-	resourceComparator.SetComparator(pvcType, resourceComparator.GetDefaultComparator())
-	resourceComparator.SetComparator(svcType, resourceComparator.GetComparator(svcType))
-	resourceComparator.SetComparator(deploymentType, resourceComparator.GetComparator(deploymentType))
-	resourceComparator.SetComparator(routeType, resourceComparator.GetComparator(routeType))
+	ingressType := reflect.TypeOf(networkingv1beta1.Ingress{})
 	resourceComparator.SetComparator(ingressType, ingressEqual)
-	resourceComparator.SetComparator(svcAccntType, rbac.GetComparator(svcAccntType))
 
 	return compare.MapComparator{Comparator: resourceComparator}
 }
 
 func ingressEqual(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
-	ingress1 := deployed.(*v1beta1.Ingress)
-	ingress2 := deployed.(*v1beta1.Ingress)
+	ingress1 := deployed.(*networkingv1beta1.Ingress)
+	ingress2 := requested.(*networkingv1beta1.Ingress)
 	var pairs [][2]interface{}
 	pairs = append(pairs, [2]interface{}{ingress1.Name, ingress2.Name})
 	pairs = append(pairs, [2]interface{}{ingress1.Namespace, ingress2.Namespace})


### PR DESCRIPTION
Also removes unnecessary comparator function assignments for resources
which operator-utils knows how to handle.

Fixes #73 

Signed-off-by: Lucas Caparelli <lucas.caparelli112@gmail.com>