### PR TITLE
Only assign UID if using the community image

### DIFF
--- a/.github/workflows/nexus-operator-integration-checks.yml
+++ b/.github/workflows/nexus-operator-integration-checks.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.27
+          args: --timeout=2m
 
   unit_test:
     name: Unit Tests

--- a/pkg/controller/nexus/resource/deployment/deployment.go
+++ b/pkg/controller/nexus/resource/deployment/deployment.go
@@ -89,7 +89,6 @@ func newDeployment(nexus *v1alpha1.Nexus) *appsv1.Deployment {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: meta.DefaultObjectMeta(nexus),
 				Spec: corev1.PodSpec{
-					SecurityContext: &corev1.PodSecurityContext{FSGroup: &nexusUID, RunAsUser: &nexusUID, SupplementalGroups: []int64{nexusUID}},
 					Containers: []corev1.Container{
 						{
 							Name: nexusContainerName,
@@ -117,6 +116,7 @@ func newDeployment(nexus *v1alpha1.Nexus) *appsv1.Deployment {
 	addProbes(nexus, deployment)
 	applyJVMArgs(nexus, deployment)
 	addServiceAccount(nexus, deployment)
+	applySecurityContext(nexus, deployment)
 
 	return deployment
 }
@@ -260,4 +260,12 @@ func addServiceAccount(nexus *v1alpha1.Nexus, deployment *appsv1.Deployment) {
 	} else {
 		deployment.Spec.Template.Spec.ServiceAccountName = nexus.Name
 	}
+}
+
+func applySecurityContext(nexus *v1alpha1.Nexus, deployment *appsv1.Deployment) {
+	var podSecContext *corev1.PodSecurityContext
+	if !nexus.Spec.UseRedHatImage {
+		podSecContext = &corev1.PodSecurityContext{FSGroup: &nexusUID, RunAsUser: &nexusUID, SupplementalGroups: []int64{nexusUID}}
+	}
+	deployment.Spec.Template.Spec.SecurityContext = podSecContext
 }


### PR DESCRIPTION
Partially resolves #51 by not assigning a specific UID to the deployment template, thus allowing the pods to run within the range accepted by the `restricted` default SCC.

Signed-off-by: Lucas Caparelli <lucas.caparelli112@gmail.com>