### PR TITLE
Move resource managing interfaces to a separate package

### DIFF
--- a/pkg/controller/nexus/resource/deployment/manager.go
+++ b/pkg/controller/nexus/resource/deployment/manager.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"github.com/RHsyseng/operator-utils/pkg/resource"
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/infra"
 	"github.com/m88i/nexus-operator/pkg/logger"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -42,7 +43,7 @@ type manager struct {
 }
 
 // NewManager creates a deployment resources manager
-func NewManager(nexus *v1alpha1.Nexus, client client.Client) *manager {
+func NewManager(nexus *v1alpha1.Nexus, client client.Client) infra.Manager {
 	return &manager{
 		nexus:  nexus,
 		client: client,

--- a/pkg/controller/nexus/resource/infra/interfaces.go
+++ b/pkg/controller/nexus/resource/infra/interfaces.go
@@ -1,0 +1,51 @@
+//     Copyright 2020 Nexus Operator and/or its authors
+//
+//     This file is part of Nexus Operator.
+//
+//     Nexus Operator is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Nexus Operator is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Nexus Operator.  If not, see <https://www.gnu.org/licenses/>.
+
+package infra
+
+import (
+	"github.com/RHsyseng/operator-utils/pkg/resource"
+	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"reflect"
+)
+
+// Supervisor is the resources manager for the nexus CR.
+// Handles the creation of every single resource needed to deploy a nexus server instance on Kubernetes
+type Supervisor interface {
+	// InitManagers initializes the managers responsible for the resources life cycle
+	InitManagers(nexus *v1alpha1.Nexus) error
+	// GetDeployedResources will fetch for the resources managed by the nexus instance deployed in the cluster
+	GetDeployedResources() (resources map[reflect.Type][]resource.KubernetesResource, err error)
+	// GetRequiredResources will create the requests resources as it's supposed to be
+	GetRequiredResources() (resources map[reflect.Type][]resource.KubernetesResource, err error)
+	// GetComparator returns the comparator based on the active managers
+	GetComparator() (compare.MapComparator, error)
+}
+
+type Manager interface {
+	// GetRequiredResources returns the resources initialized by the manager
+	GetRequiredResources() ([]resource.KubernetesResource, error)
+	// GetDeployedResources returns the resources deployed on the cluster
+	GetDeployedResources() ([]resource.KubernetesResource, error)
+	// GetCustomComparator returns the custom comp function used to compare two resources of a specific type
+	// Returns nil if there is no custom comparator for that type
+	GetCustomComparator(t reflect.Type) func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool
+	// GetCustomComparators returns all custom comp functions in a map indexed by the resource type
+	// Returns nil if there are none
+	GetCustomComparators() map[reflect.Type]func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool
+}

--- a/pkg/controller/nexus/resource/networking/manager.go
+++ b/pkg/controller/nexus/resource/networking/manager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	"github.com/m88i/nexus-operator/pkg/cluster/kubernetes"
 	"github.com/m88i/nexus-operator/pkg/cluster/openshift"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/infra"
 	"github.com/m88i/nexus-operator/pkg/logger"
 	routev1 "github.com/openshift/api/route/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
@@ -52,7 +53,7 @@ type manager struct {
 }
 
 // NewManager creates a networking resources manager
-func NewManager(nexus *v1alpha1.Nexus, client client.Client, disc discovery.DiscoveryInterface) (*manager, error) {
+func NewManager(nexus *v1alpha1.Nexus, client client.Client, disc discovery.DiscoveryInterface) (infra.Manager, error) {
 	routeAvailable, err := openshift.IsRouteAvailable(disc)
 	if err != nil {
 		return nil, fmt.Errorf(discFailureFormat, "routes", err)

--- a/pkg/controller/nexus/resource/persistence/manager.go
+++ b/pkg/controller/nexus/resource/persistence/manager.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"github.com/RHsyseng/operator-utils/pkg/resource"
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/infra"
 	"github.com/m88i/nexus-operator/pkg/logger"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -41,7 +42,7 @@ type manager struct {
 }
 
 // NewManager creates a persistence resources manager
-func NewManager(nexus *v1alpha1.Nexus, client client.Client) *manager {
+func NewManager(nexus *v1alpha1.Nexus, client client.Client) infra.Manager {
 	return &manager{
 		nexus:  nexus,
 		client: client,

--- a/pkg/controller/nexus/resource/resources.go
+++ b/pkg/controller/nexus/resource/resources.go
@@ -19,6 +19,7 @@ package resource
 
 import (
 	"fmt"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/infra"
 
 	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
@@ -38,54 +39,28 @@ import (
 
 const mgrsNotInit = "resource managers have not been initialized"
 
-// NexusResourceManager is the resources manager for the nexus CR.
-// Handles the creation of every single resource needed to deploy a nexus server instance on Kubernetes
-type NexusResourceManager interface {
-	// InitManagers initializes the managers responsible for the resources life cycle
-	InitManagers(nexus *v1alpha1.Nexus) error
-	// GetDeployedResources will fetch for the resources managed by the nexus instance deployed in the cluster
-	GetDeployedResources() (resources map[reflect.Type][]resource.KubernetesResource, err error)
-	// GetRequiredResources will create the requests resources as it's supposed to be
-	GetRequiredResources() (resources map[reflect.Type][]resource.KubernetesResource, err error)
-	// GetComparator returns the comparator based on the active managers
-	GetComparator() (compare.MapComparator, error)
-}
-
-type Manager interface {
-	// GetRequiredResources returns the resources initialized by the manager
-	GetRequiredResources() ([]resource.KubernetesResource, error)
-	// GetDeployedResources returns the resources deployed on the cluster
-	GetDeployedResources() ([]resource.KubernetesResource, error)
-	// GetCustomComparator returns the custom comp function used to compare two resources of a specific type
-	// Returns nil if there is no custom comparator for that type
-	GetCustomComparator(t reflect.Type) func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool
-	// GetCustomComparators returns all custom comp functions in a map indexed by the resource type
-	// Returns nil if there are none
-	GetCustomComparators() map[reflect.Type]func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool
-}
-
-type nexusResourceManager struct {
+type supervisor struct {
 	client          client.Client
 	discoveryClient discovery.DiscoveryInterface
-	managers        []Manager
+	managers        []infra.Manager
 }
 
-// New creates a new resource manager for nexus CR
-func New(client client.Client, discoveryClient discovery.DiscoveryInterface) NexusResourceManager {
-	return &nexusResourceManager{
+// NewSupervisor creates a new resource manager for nexus CR
+func NewSupervisor(client client.Client, discoveryClient discovery.DiscoveryInterface) infra.Supervisor {
+	return &supervisor{
 		client:          client,
 		discoveryClient: discoveryClient,
 	}
 }
 
 // InitManagers initializes the managers responsible for the resources life cycle
-func (r *nexusResourceManager) InitManagers(nexus *v1alpha1.Nexus) error {
+func (r *supervisor) InitManagers(nexus *v1alpha1.Nexus) error {
 	networkManager, err := networking.NewManager(nexus, r.client, r.discoveryClient)
 	if err != nil {
 		return fmt.Errorf("unable to create networking manager: %v", err)
 	}
 
-	r.managers = []Manager{
+	r.managers = []infra.Manager{
 		deployment.NewManager(nexus, r.client),
 		persistence.NewManager(nexus, r.client),
 		security.NewManager(nexus, r.client),
@@ -94,7 +69,7 @@ func (r *nexusResourceManager) InitManagers(nexus *v1alpha1.Nexus) error {
 	return nil
 }
 
-func (r *nexusResourceManager) GetDeployedResources() (map[reflect.Type][]resource.KubernetesResource, error) {
+func (r *supervisor) GetDeployedResources() (map[reflect.Type][]resource.KubernetesResource, error) {
 	if len(r.managers) == 0 {
 		return nil, fmt.Errorf(mgrsNotInit)
 	}
@@ -111,7 +86,7 @@ func (r *nexusResourceManager) GetDeployedResources() (map[reflect.Type][]resour
 	return builder.ResourceMap(), nil
 }
 
-func (r *nexusResourceManager) GetRequiredResources() (resources map[reflect.Type][]resource.KubernetesResource, err error) {
+func (r *supervisor) GetRequiredResources() (resources map[reflect.Type][]resource.KubernetesResource, err error) {
 	if len(r.managers) == 0 {
 		return nil, fmt.Errorf(mgrsNotInit)
 	}
@@ -130,7 +105,7 @@ func (r *nexusResourceManager) GetRequiredResources() (resources map[reflect.Typ
 
 // GetComparator will create the comparator for the Nexus instance
 // The comparator can be used to compare two different sets of resources and update them accordingly
-func (r *nexusResourceManager) GetComparator() (compare.MapComparator, error) {
+func (r *supervisor) GetComparator() (compare.MapComparator, error) {
 	if len(r.managers) == 0 {
 		return compare.MapComparator{}, fmt.Errorf(mgrsNotInit)
 	}

--- a/pkg/controller/nexus/resource/security/manager.go
+++ b/pkg/controller/nexus/resource/security/manager.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"github.com/RHsyseng/operator-utils/pkg/resource"
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/infra"
 	"github.com/m88i/nexus-operator/pkg/logger"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -41,7 +42,7 @@ type manager struct {
 }
 
 // NewManager creates a security resources manager
-func NewManager(nexus *v1alpha1.Nexus, client client.Client) *manager {
+func NewManager(nexus *v1alpha1.Nexus, client client.Client) infra.Manager {
 	return &manager{
 		nexus:  nexus,
 		client: client,


### PR DESCRIPTION
Notable changes:

  - Rename the `NexusResourceManager` interface to `Supervisor` as it is
   responsible for managing the Resource Managers
  - Move the `Supervisor` and `Manager` interfaces to the newly created
  `infra` package so that they can be used as return types for the
  `NewManager` functions without generating an import cycle

Signed-off-by: Lucas Caparelli <lucas.caparelli112@gmail.com>