### PR TITLE
Add networking E2E tests

### DIFF
--- a/.github/workflows/nexus-operator-integration-checks.yml
+++ b/.github/workflows/nexus-operator-integration-checks.yml
@@ -130,6 +130,7 @@ jobs:
       - name: Run e2e test
         env:
           RUN_WITH_IMAGE: true
+          TIMEOUT_E2E: 20m
         run: ./hack/run-e2e-test.sh
 
       - name: Run Operator OLM Integration Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,20 +93,20 @@ In previous examples, `tester.defaultCleanup` was used, which simply deletes all
 
 ```go
 {
-	name: "Test Example: this counts to 5 during cleanup and uses the default cleanup once done",
-	input: &v1alpha1.Nexus{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      nexusName,
-			Namespace: namespace,
-		},
-		Spec: defaultNexusSpec,
-	},
-	cleanup: func() error {
+    name: "Test Example: this counts to 5 during cleanup and uses the default cleanup once done",
+    input: &v1alpha1.Nexus{
+        ObjectMeta: metav1.ObjectMeta{
+            Name:      nexusName,
+            Namespace: namespace,
+        },
+        Spec: defaultNexusSpec,
+    },
+    cleanup: func() error {
         for i := 0; i < 5; i++ {
             tester.t.Logf("Count: %d", i)
         }
-		return tester.defaultCleanup()
-	},
+        return tester.defaultCleanup()
+    },
     additionalChecks: nil,
 },
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,3 +18,143 @@ Regarding your local development environment:
 2. **Always** run `make test` before sending a PR to make sure the license headers and the manifests are updated (and of course the unit tests are passing)
 3. Consider adding a new [end-to-end](https://sdk.operatorframework.io/docs/golang/e2e-tests/) test case covering your scenario and make sure to run `make test-e2e` before sending the PR
 4. Make sure to always keep your version of `Go` and the `operator-sdk` on par with the project. The current version information can be found at [the go.mod file](go.mod)
+
+## E2E Testing
+
+If you added a new functionality and are willing to add some end-to-end (E2E) testing of your own, please add a test case to `test/e2e/nexus_test.go`.
+
+The test case structure allows you to name your test appropriately (try naming it in a way it's clear what it's testing), provide a Nexus CR that the Operator will use to generate the other resources, provide additional checks your feature may require and provide a custom cleanup function if necessary.
+
+Then each test case is submitted to a series of checks which should make sure everything on the cluster is as it should, based on the Nexus CR that has been defined.
+
+Let's take our smoke test as an example to go over the test cases structure:
+
+```go
+testCases := []struct {
+	name             string (1)
+	input            *v1alpha1.Nexus (2)
+	cleanup          func() error (3)
+	additionalChecks []func(nexus *v1alpha1.Nexus) error (4)
+}{
+	{
+		name: "Smoke test: no persistence, nodeport exposure", (1)
+		input: &v1alpha1.Nexus{ (2)
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nexusName,
+				Namespace: namespace,
+			},
+			Spec: defaultNexusSpec, (5)
+		},
+		cleanup: tester.defaultCleanup, (3)
+		additionalChecks: nil, (4)
+	},
+```
+
+> (1): the test case's name. In this scenario we're testing a deployment with all default values, no persistence and exposed via Node Port.
+> (2): the Nexus CR which the Operator will use to orchestrate and maintain your Nexus3 deployment
+> (3): a cleanup function which should be ran after the test has been completed
+> (4): additional checks your test case may need
+> (5): the base, default Nexus CR specification which should be used for testing. Modify this to test your own features
+
+**Important**: although the operator will set the defaults on the Nexus CR you provide it with, the tests will use your original CR for comparison, so be sure to make a completely valid Nexus CR for your test case as it *will not* be modified to insert default values.
+
+### Custom Nexus CR
+
+If your test requires modifications to the default Nexus CR, you can do so directly and concisely when defining the test case by making use of anonymous functions.
+
+For example:
+
+```go
+{
+    name: "Networking: ingress with no TLS",
+    input: &v1alpha1.Nexus{
+        ObjectMeta: metav1.ObjectMeta{
+            Name:      nexusName,
+            Namespace: namespace,
+        },
+        Spec: func() v1alpha1.NexusSpec {
+            spec := *defaultNexusSpec.DeepCopy()
+            spec.Networking = v1alpha1.NexusNetworking{Expose: true, ExposeAs: v1alpha1.IngressExposeType, Host: "test-example.com"}
+            return spec
+        }(),
+    },
+    cleanup: tester.defaultCleanup,
+    additionalChecks: nil,
+},
+```
+
+When defining the Nexus's specification in this case we're actually calling an anonymous function that acquires the default spec, modifies the required fields and then returns that spec, thus making the necessary changes for the test.
+
+### Custom Cleanup functions
+
+Our test cases make use of [functions first-class citizenship in Go](https://golang.org/doc/codewalk/functions/) by declaring the cleanup function as a field from the test case. This way it's possible to specify our own custom cleanup function for a test.
+
+In previous examples, `tester.defaultCleanup` was used, which simply deletes all Nexus CRs in the namespace, but you may want to do some additional computation when cleaning up, such as counting to 5 (intentionally useless to promote simplicity in this example):
+
+```go
+{
+	name: "Test Example: this counts to 5 during cleanup and uses the default cleanup once done",
+	input: &v1alpha1.Nexus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nexusName,
+			Namespace: namespace,
+		},
+		Spec: defaultNexusSpec,
+	},
+	cleanup: func() error {
+        for i := 0; i < 5; i++ {
+            tester.t.Logf("Count: %d", i)
+        }
+		return tester.defaultCleanup()
+	},
+    additionalChecks: nil,
+},
+```
+
+It's possible, of course, to not use the default cleanup function at all, but be sure to actually delete the resources you created if they conflict with other test cases (the framework itself will delete the whole namespace once the tests are done):
+
+```go
+{
+	name: "Test Example: this only counts to 5 during cleanup and does not delete anything",
+	input: &v1alpha1.Nexus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nexusName,
+			Namespace: namespace,
+		},
+		Spec: defaultNexusSpec,
+	},
+	cleanup: func() error {
+		for i := 0; i < 5; i++ {
+			tester.t.Logf("Count: %d", i)
+		}
+		return nil
+	},
+	additionalChecks: nil,
+},
+```
+
+### Running additional checks
+
+If your testing needs to check something that isn't already checked by default you may add functions to perform these checks as the function that is responsible for running the default checks will receive them as [variadic arguments](https://gobyexample.com/variadic-functions).
+
+In another useless yet simple example, let's also make sure that 5 is greater than 4 when performing our checks:
+
+```go
+{
+	name: "Test Example: this will also check if 5 > 4",
+	input: &v1alpha1.Nexus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nexusName,
+			Namespace: namespace,
+		},
+		Spec: defaultNexusSpec,
+	},
+	cleanup: tester.defaultCleanup,
+	additionalChecks: []func(nexus *v1alpha1.Nexus)error{
+		func(nexus *v1alpha1.Nexus) error {
+			assert.Greater(tester.t, 5, 4)
+			return nil
+		},
+	},
+},
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,11 +50,11 @@ testCases := []struct {
 	},
 ```
 
-> (1): the test case's name. In this scenario we're testing a deployment with all default values, no persistence and exposed via Node Port.
-> (2): the Nexus CR which the Operator will use to orchestrate and maintain your Nexus3 deployment
-> (3): a cleanup function which should be ran after the test has been completed
-> (4): additional checks your test case may need
-> (5): the base, default Nexus CR specification which should be used for testing. Modify this to test your own features
+> (1): the test case's name. In this scenario we're testing a deployment with all default values, no persistence and exposed via Node Port.<br>
+> (2): the Nexus CR which the Operator will use to orchestrate and maintain your Nexus3 deployment<br>
+> (3): a cleanup function which should be ran after the test has been completed<br>
+> (4): additional checks your test case may need<br>
+> (5): the base, default Nexus CR specification which should be used for testing. Modify this to test your own features<br>
 
 **Important**: although the operator will set the defaults on the Nexus CR you provide it with, the tests will use your original CR for comparison, so be sure to make a completely valid Nexus CR for your test case as it *will not* be modified to insert default values.
 

--- a/hack/run-e2e-test.sh
+++ b/hack/run-e2e-test.sh
@@ -20,6 +20,10 @@ if [[ -z ${NAMESPACE_E2E} ]]; then
     NAMESPACE_E2E="nexus-e2e"
 fi
 
+if [[ -z ${TIMEOUT_E2E} ]]; then
+	TIMEOUT_E2E="15m"
+fi
+
 if [[ ${CREATE_NAMESPACE^^} == "TRUE" ]]; then
     echo "---> Creating Namespace ${NAMESPACE_E2E} to run e2e tests"
     kubectl create namespace $NAMESPACE_E2E
@@ -34,10 +38,10 @@ if [[ ${RUN_WITH_IMAGE^^} == "TRUE" ]]; then
     # see: https://kind.sigs.k8s.io/docs/user/quick-start/#loading-an-image-into-your-cluster
     echo "---> Updating deployment file to imagePullPolicy: Never"
     sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' ./deploy/operator.yaml
-    operator-sdk test local ./test/e2e --go-test-flags "-v" --debug --operator-namespace $NAMESPACE_E2E
+    operator-sdk test local ./test/e2e --go-test-flags "-v -timeout $TIMEOUT_E2E" --debug --operator-namespace $NAMESPACE_E2E
 else
     echo "---> Running tests with local binary"
-    operator-sdk test local ./test/e2e --go-test-flags "-v" --debug --up-local --operator-namespace $NAMESPACE_E2E
+    operator-sdk test local ./test/e2e --go-test-flags "-v -timeout $TIMEOUT_E2E" --debug --up-local --operator-namespace $NAMESPACE_E2E
 fi
 
 test_exit_code=$?

--- a/pkg/controller/nexus/resource/deployment/deployment.go
+++ b/pkg/controller/nexus/resource/deployment/deployment.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	jvmArgsEnvKey = "INSTALL4J_ADD_VM_PARAMS"
+	JvmArgsEnvKey = "INSTALL4J_ADD_VM_PARAMS"
 	/*
 		1. Xms
 		2. Xmx
@@ -79,7 +79,7 @@ func newDeployment(nexus *v1alpha1.Nexus) *appsv1.Deployment {
 							Name: nexusContainerName,
 							Ports: []corev1.ContainerPort{
 								{
-									Name:          "http",
+									Name:          NexusPortName,
 									ContainerPort: NexusServicePort,
 									Protocol:      corev1.ProtocolTCP,
 								},
@@ -200,7 +200,7 @@ func applyJVMArgs(nexus *v1alpha1.Nexus, deployment *appsv1.Deployment) {
 	deployment.Spec.Template.Spec.Containers[0].Env =
 		append(deployment.Spec.Template.Spec.Containers[0].Env,
 			corev1.EnvVar{
-				Name:  jvmArgsEnvKey,
+				Name:  JvmArgsEnvKey,
 				Value: jvmArgs.String(),
 			})
 }

--- a/pkg/controller/nexus/resource/deployment/deployment_test.go
+++ b/pkg/controller/nexus/resource/deployment/deployment_test.go
@@ -43,15 +43,15 @@ func Test_newDeployment_WithoutPersistence(t *testing.T) {
 			},
 			// a valid Liveness Probe should have successThreshold == 1
 			// but we don't care about that here (this is tested on the manager's tests)
-			LivenessProbe:  defaultProbe,
-			ReadinessProbe: defaultProbe,
-			Image:          nexusCommunityLatestImage,
+			LivenessProbe:  DefaultProbe,
+			ReadinessProbe: DefaultProbe,
+			Image:          NexusCommunityLatestImage,
 		},
 	}
 	deployment := newDeployment(nexus)
 
 	assert.Len(t, deployment.Spec.Template.Spec.Containers, 1)
-	assert.Equal(t, nexusCommunityLatestImage, deployment.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, NexusCommunityLatestImage, deployment.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, int32(1), *deployment.Spec.Replicas)
 
 	assert.Equal(t, int32(NexusServicePort), deployment.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Port.IntVal)
@@ -79,8 +79,8 @@ func Test_newDeployment_WithPersistence(t *testing.T) {
 			},
 			// a valid Liveness Probe should have successThreshold == 1
 			// but we don't care about that here (this is tested on the manager's tests)
-			LivenessProbe:  defaultProbe,
-			ReadinessProbe: defaultProbe,
+			LivenessProbe:  DefaultProbe,
+			ReadinessProbe: DefaultProbe,
 		},
 	}
 	deployment := newDeployment(nexus)
@@ -159,7 +159,7 @@ func Test_customProbes(t *testing.T) {
 				SuccessThreshold:    3,
 				TimeoutSeconds:      15,
 			},
-			ReadinessProbe: defaultProbe,
+			ReadinessProbe: DefaultProbe,
 		},
 	}
 	deployment := newDeployment(nexus)
@@ -185,8 +185,8 @@ func Test_applyJVMArgs_withRandomPassword(t *testing.T) {
 			GenerateRandomAdminPassword: true,
 			// a valid Liveness Probe should have successThreshold == 1
 			// but we don't care about that here (this is tested on the manager's tests)
-			LivenessProbe:  defaultProbe,
-			ReadinessProbe: defaultProbe,
+			LivenessProbe:  DefaultProbe,
+			ReadinessProbe: DefaultProbe,
 		},
 	}
 	deployment := newDeployment(nexus)
@@ -210,8 +210,8 @@ func Test_applyJVMArgs_withDefaultValues(t *testing.T) {
 			},
 			// a valid Liveness Probe should have successThreshold == 1
 			// but we don't care about that here (this is tested on the manager's tests)
-			LivenessProbe:  defaultProbe,
-			ReadinessProbe: defaultProbe,
+			LivenessProbe:  DefaultProbe,
+			ReadinessProbe: DefaultProbe,
 		},
 	}
 	deployment := newDeployment(nexus)

--- a/pkg/controller/nexus/resource/deployment/manager.go
+++ b/pkg/controller/nexus/resource/deployment/manager.go
@@ -35,8 +35,8 @@ import (
 )
 
 const (
-	nexusCommunityLatestImage       = "docker.io/sonatype/nexus3:latest"
-	nexusCertifiedLatestImage       = "registry.connect.redhat.com/sonatype/nexus-repository-manager"
+	NexusCommunityLatestImage       = "docker.io/sonatype/nexus3:latest"
+	NexusCertifiedLatestImage       = "registry.connect.redhat.com/sonatype/nexus-repository-manager"
 	mgrNotInit                      = "the manager has not been initialized"
 	probeDefaultInitialDelaySeconds = int32(240)
 	probeDefaultTimeoutSeconds      = int32(15)
@@ -46,9 +46,7 @@ const (
 )
 
 var (
-	log = logger.GetLogger("deployment_manager")
-
-	defaultResources = corev1.ResourceRequirements{
+	DefaultResources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			corev1.ResourceCPU:    k8sres.MustParse("2"),
 			corev1.ResourceMemory: k8sres.MustParse("2Gi"),
@@ -59,13 +57,15 @@ var (
 		},
 	}
 
-	defaultProbe = &v1alpha1.NexusProbe{
+	DefaultProbe = &v1alpha1.NexusProbe{
 		InitialDelaySeconds: probeDefaultInitialDelaySeconds,
 		TimeoutSeconds:      probeDefaultTimeoutSeconds,
 		PeriodSeconds:       probeDefaultPeriodSeconds,
 		SuccessThreshold:    probeDefaultSuccessThreshold,
 		FailureThreshold:    probeDefaultFailureThreshold,
 	}
+
+	log = logger.GetLogger("deployment_manager")
 )
 
 // manager is responsible for creating deployment-related resources, fetching deployed ones and comparing them
@@ -100,7 +100,7 @@ func (m *manager) setSvcAccntDefaults() {
 
 func (m *manager) setResourcesDefaults() {
 	if m.nexus.Spec.Resources.Requests == nil && m.nexus.Spec.Resources.Limits == nil {
-		m.nexus.Spec.Resources = defaultResources
+		m.nexus.Spec.Resources = DefaultResources
 	}
 }
 
@@ -109,9 +109,9 @@ func (m *manager) setImageDefaults() {
 		if len(m.nexus.Spec.Image) > 0 {
 			log.Warnf("Nexus CR configured to the use Red Hat Certified Image, ignoring 'spec.image' field.")
 		}
-		m.nexus.Spec.Image = nexusCertifiedLatestImage
+		m.nexus.Spec.Image = NexusCertifiedLatestImage
 	} else if len(m.nexus.Spec.Image) == 0 {
-		m.nexus.Spec.Image = nexusCommunityLatestImage
+		m.nexus.Spec.Image = NexusCommunityLatestImage
 	}
 
 	if len(m.nexus.Spec.ImagePullPolicy) > 0 &&
@@ -135,7 +135,7 @@ func (m *manager) setProbeDefaults() {
 		m.nexus.Spec.LivenessProbe.TimeoutSeconds =
 			util.EnsureMinimum(m.nexus.Spec.LivenessProbe.TimeoutSeconds, 1)
 	} else {
-		m.nexus.Spec.LivenessProbe = defaultProbe.DeepCopy()
+		m.nexus.Spec.LivenessProbe = DefaultProbe.DeepCopy()
 	}
 
 	// SuccessThreshold for Liveness Probes must be 1
@@ -153,7 +153,7 @@ func (m *manager) setProbeDefaults() {
 		m.nexus.Spec.ReadinessProbe.TimeoutSeconds =
 			util.EnsureMinimum(m.nexus.Spec.ReadinessProbe.TimeoutSeconds, 1)
 	} else {
-		m.nexus.Spec.ReadinessProbe = defaultProbe.DeepCopy()
+		m.nexus.Spec.ReadinessProbe = DefaultProbe.DeepCopy()
 	}
 }
 

--- a/pkg/controller/nexus/resource/deployment/manager_test.go
+++ b/pkg/controller/nexus/resource/deployment/manager_test.go
@@ -30,15 +30,15 @@ func TestNewManager_setDefaults(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "nexus-test"},
 		Spec: v1alpha1.NexusSpec{
 			ServiceAccountName: "nexus-test",
-			Resources:          defaultResources,
-			Image:              nexusCommunityLatestImage,
-			LivenessProbe:      defaultProbe.DeepCopy(),
-			ReadinessProbe:     defaultProbe.DeepCopy(),
+			Resources:          DefaultResources,
+			Image:              NexusCommunityLatestImage,
+			LivenessProbe:      DefaultProbe.DeepCopy(),
+			ReadinessProbe:     DefaultProbe.DeepCopy(),
 		},
 	}
 	allDefaultsRedHatNexus := allDefaultsCommunityNexus.DeepCopy()
 	allDefaultsRedHatNexus.Spec.UseRedHatImage = true
-	allDefaultsRedHatNexus.Spec.Image = nexusCertifiedLatestImage
+	allDefaultsRedHatNexus.Spec.Image = NexusCertifiedLatestImage
 
 	minimumDefaultProbe := &v1alpha1.NexusProbe{
 		InitialDelaySeconds: 0,

--- a/pkg/controller/nexus/resource/deployment/service.go
+++ b/pkg/controller/nexus/resource/deployment/service.go
@@ -25,8 +25,8 @@ import (
 )
 
 const (
+	NexusPortName    = "http"
 	NexusServicePort = 8081
-	nexusPortName    = "http"
 )
 
 func newService(nexus *v1alpha1.Nexus) *corev1.Service {
@@ -35,7 +35,7 @@ func newService(nexus *v1alpha1.Nexus) *corev1.Service {
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
-					Name:     nexusPortName,
+					Name:     NexusPortName,
 					Protocol: corev1.ProtocolTCP,
 					Port:     NexusServicePort,
 					TargetPort: intstr.IntOrString{

--- a/test/e2e/nexus_test.go
+++ b/test/e2e/nexus_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
+	corev1 "k8s.io/api/core/v1"
 	"testing"
 	"time"
 
@@ -24,6 +25,7 @@ var (
 		spec := v1alpha1.NexusSpec{
 			Replicas:                    1,
 			Image:                       deployment.NexusCommunityLatestImage,
+			ImagePullPolicy:             corev1.PullIfNotPresent,
 			Resources:                   deployment.DefaultResources,
 			Persistence:                 v1alpha1.NexusPersistence{Persistent: false},
 			UseRedHatImage:              false,

--- a/test/e2e/nexus_test.go
+++ b/test/e2e/nexus_test.go
@@ -1,31 +1,41 @@
 package e2e
 
 import (
-	goctx "context"
-	"fmt"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
 	"testing"
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
-
-	v1 "k8s.io/api/core/v1"
-
 	"github.com/m88i/nexus-operator/pkg/apis"
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/stretchr/testify/assert"
-
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
+
+const nexusName = "nexus3"
 
 var (
 	retryInterval        = time.Second * 10
 	timeout              = time.Second * 360
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Second * 5
+
+	defaultNexusSpec = func() v1alpha1.NexusSpec {
+		spec := v1alpha1.NexusSpec{
+			Replicas:                    1,
+			Image:                       deployment.NexusCommunityLatestImage,
+			Resources:                   deployment.DefaultResources,
+			Persistence:                 v1alpha1.NexusPersistence{Persistent: false},
+			UseRedHatImage:              false,
+			GenerateRandomAdminPassword: false,
+			Networking:                  v1alpha1.NexusNetworking{Expose: true, NodePort: 31031, ExposeAs: v1alpha1.NodePortExposeType},
+			ServiceAccountName:          nexusName,
+			LivenessProbe:               deployment.DefaultProbe.DeepCopy(),
+			ReadinessProbe:              deployment.DefaultProbe.DeepCopy(),
+		}
+		spec.LivenessProbe.InitialDelaySeconds = 240
+		return spec
+	}()
 )
 
 func TestNexus(t *testing.T) {
@@ -40,57 +50,6 @@ func TestNexus(t *testing.T) {
 	})
 }
 
-func nexusNoPersitenceNodePort(t *testing.T, f *framework.Framework, ctx *framework.Context) error {
-	namespace, err := ctx.GetNamespace()
-	if err != nil {
-		return fmt.Errorf("could not get namespace: %v", err)
-	}
-	// create nexus custom resource
-	nexus3 := &v1alpha1.Nexus{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "nexus3",
-			Namespace: namespace,
-		},
-		Spec: v1alpha1.NexusSpec{
-			Replicas:       1,
-			Networking:     v1alpha1.NexusNetworking{Expose: true, NodePort: 31031, ExposeAs: v1alpha1.NodePortExposeType},
-			Persistence:    v1alpha1.NexusPersistence{Persistent: false},
-			UseRedHatImage: false,
-			LivenessProbe:  &v1alpha1.NexusProbe{InitialDelaySeconds: 240},
-		},
-	}
-	// use TestCtx's create helper to create the object and add a cleanup function for the new object
-	err = f.Client.Create(goctx.TODO(), nexus3, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-	if err != nil {
-		return err
-	}
-	// wait for nexus3 to finish deployment
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "nexus3", 1, retryInterval, timeout)
-	assert.NoError(t, err)
-
-	// check the service
-	svc := &v1.Service{}
-	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: nexus3.Name, Namespace: nexus3.Namespace}, svc)
-	assert.NoError(t, err)
-	assert.NotNil(t, svc)
-	assert.Equal(t, nexus3.Spec.Networking.NodePort, svc.Spec.Ports[0].NodePort)
-
-	// we don't have a PVC created
-	pvc := &v1.PersistentVolumeClaim{}
-	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: nexus3.Name, Namespace: nexus3.Namespace}, pvc)
-	assert.Error(t, err)
-	assert.True(t, errors.IsNotFound(err))
-
-	// guarantee that we have set the correct default limits
-	deployment := &appsv1.Deployment{}
-	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: nexus3.Name, Namespace: nexus3.Namespace}, deployment)
-	assert.NoError(t, err)
-	assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String(), "2Gi")
-	assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String(), "2Gi")
-
-	return nil
-}
-
 func NexusCluster(t *testing.T) {
 	t.Parallel()
 	ctx := framework.NewContext(t)
@@ -100,7 +59,7 @@ func NexusCluster(t *testing.T) {
 		t.Fatalf("failed to initialize cluster resources: %v", err)
 	}
 	t.Log("Initialized cluster resources")
-	namespace, err := ctx.GetNamespace()
+	namespace, err := ctx.GetOperatorNamespace()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +71,71 @@ func NexusCluster(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = nexusNoPersitenceNodePort(t, f, ctx); err != nil {
-		t.Fatal(err)
+	tester := &tester{
+		t:   t,
+		f:   f,
+		ctx: ctx,
+	}
+
+	testCases := []struct {
+		name             string
+		input            *v1alpha1.Nexus
+		cleanup          func() error
+		additionalChecks []func(nexus *v1alpha1.Nexus) error
+	}{
+		{
+			name: "Smoke test: no persistence, nodeport exposure",
+			input: &v1alpha1.Nexus{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nexusName,
+					Namespace: namespace,
+				},
+				Spec: defaultNexusSpec,
+			},
+			cleanup:          tester.defaultCleanup,
+			additionalChecks: nil,
+		},
+		{
+			name: "Networking: ingress with no TLS",
+			input: &v1alpha1.Nexus{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nexusName,
+					Namespace: namespace,
+				},
+				Spec: func() v1alpha1.NexusSpec {
+					spec := *defaultNexusSpec.DeepCopy()
+					spec.Networking = v1alpha1.NexusNetworking{Expose: true, ExposeAs: v1alpha1.IngressExposeType, Host: "test-example.com"}
+					return spec
+				}(),
+			},
+			cleanup:          tester.defaultCleanup,
+			additionalChecks: nil,
+		},
+		{
+			name: "Networking: ingress with TLS secret",
+			input: &v1alpha1.Nexus{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nexusName,
+					Namespace: namespace,
+				},
+				Spec: func() v1alpha1.NexusSpec {
+					spec := *defaultNexusSpec.DeepCopy()
+					spec.Networking = v1alpha1.NexusNetworking{Expose: true, ExposeAs: v1alpha1.IngressExposeType, Host: "test-example.com", TLS: v1alpha1.NexusNetworkingTLS{SecretName: "test-secret"}}
+					return spec
+				}(),
+			},
+			cleanup:          tester.defaultCleanup,
+			additionalChecks: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		tester.t.Logf("Test: %s\nInput: %+v", testCase.name, testCase.input)
+		if err = tester.runChecks(testCase.input, testCase.additionalChecks...); err != nil {
+			tester.t.Fatal(err)
+		}
+		if err = testCase.cleanup(); err != nil {
+			tester.t.Logf("%v", err)
+		}
 	}
 }

--- a/test/e2e/tester_test.go
+++ b/test/e2e/tester_test.go
@@ -1,0 +1,202 @@
+package e2e
+
+import (
+	"context"
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
+	"github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+type tester struct {
+	t   *testing.T
+	f   *test.Framework
+	ctx *test.Context
+}
+
+func (tester *tester) defaultCleanup() error {
+	namespace, err := tester.ctx.GetOperatorNamespace()
+	if err != nil {
+		return err
+	}
+	return tester.f.Client.DeleteAllOf(context.TODO(), &v1alpha1.Nexus{}, client.InNamespace(namespace))
+}
+
+func (tester *tester) runChecks(nexus *v1alpha1.Nexus, additionalChecks ...func(nexus *v1alpha1.Nexus) error) error {
+	err := tester.createAndWait(nexus)
+	if err != nil {
+		return err
+	}
+
+	tester.checkService(nexus)
+	tester.checkPVC(nexus)
+	tester.checkDeployment(nexus)
+	tester.checkServiceAccount(nexus)
+	tester.checkIngress(nexus)
+
+	for _, check := range additionalChecks {
+		if err = check(nexus); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (tester *tester) createAndWait(nexus *v1alpha1.Nexus) error {
+	// use TestCtx's create helper to create the object and add a cleanup function for the new object
+	err := tester.f.Client.Create(context.TODO(), nexus, &test.CleanupOptions{TestContext: tester.ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	if err != nil {
+		return err
+	}
+	// wait for nexus3 to finish deployment
+	err = e2eutil.WaitForDeployment(tester.t, tester.f.KubeClient, nexus.Namespace, nexus.Name, int(nexus.Spec.Replicas), retryInterval, timeout)
+	assert.NoError(tester.t, err)
+	return nil
+}
+
+func (tester *tester) checkService(nexus *v1alpha1.Nexus) {
+	svc := &corev1.Service{}
+	err := tester.f.Client.Get(context.TODO(), types.NamespacedName{Name: nexus.Name, Namespace: nexus.Namespace}, svc)
+	assert.NoError(tester.t, err)
+	assert.NotNil(tester.t, svc)
+
+	assert.Equal(tester.t, deployment.NexusServicePort, int(svc.Spec.Ports[0].Port))
+	assert.Equal(tester.t, deployment.NexusServicePort, int(svc.Spec.Ports[0].TargetPort.IntVal))
+	assert.Equal(tester.t, deployment.NexusPortName, svc.Spec.Ports[0].Name)
+
+	if nexus.Spec.Networking.ExposeAs == v1alpha1.NodePortExposeType {
+		assert.Equal(tester.t, nexus.Spec.Networking.NodePort, svc.Spec.Ports[0].NodePort)
+		assert.Equal(tester.t, corev1.ServiceTypeNodePort, svc.Spec.Type)
+		assert.Equal(tester.t, corev1.ServiceExternalTrafficPolicyTypeCluster, svc.Spec.ExternalTrafficPolicy)
+	}
+}
+
+func (tester *tester) checkPVC(nexus *v1alpha1.Nexus) {
+	pvc := &corev1.PersistentVolumeClaim{}
+	err := tester.f.Client.Get(context.TODO(), types.NamespacedName{Name: nexus.Name, Namespace: nexus.Namespace}, pvc)
+
+	if !nexus.Spec.Persistence.Persistent {
+		assert.NotNil(tester.t, err)
+		assert.True(tester.t, errors.IsNotFound(err))
+		return
+	}
+
+	assert.Nil(tester.t, err)
+	assert.Equal(tester.t, resource.MustParse(nexus.Spec.Persistence.VolumeSize), pvc.Spec.Resources.Requests[corev1.ResourceStorage])
+
+	if nexus.Spec.Replicas > 1 {
+		assert.Equal(tester.t, corev1.ReadWriteMany, pvc.Spec.AccessModes[0])
+	} else {
+		assert.Equal(tester.t, corev1.ReadWriteOnce, pvc.Spec.AccessModes[0])
+	}
+
+	if len(nexus.Spec.Persistence.StorageClass) > 0 {
+		assert.Equal(tester.t, nexus.Spec.Persistence.StorageClass, *pvc.Spec.StorageClassName)
+	}
+}
+
+func (tester *tester) checkDeployment(nexus *v1alpha1.Nexus) {
+	d := &appsv1.Deployment{}
+	err := tester.f.Client.Get(context.TODO(), types.NamespacedName{Name: nexus.Name, Namespace: nexus.Namespace}, d)
+	assert.NoError(tester.t, err)
+
+	assert.True(tester.t, reflect.DeepEqual(d.Spec.Template.Spec.Containers[0].Resources.Requests, nexus.Spec.Resources.Requests))
+	assert.True(tester.t, reflect.DeepEqual(d.Spec.Template.Spec.Containers[0].Resources.Limits, nexus.Spec.Resources.Limits))
+
+	assert.Equal(tester.t, nexus.Spec.Replicas, *d.Spec.Replicas)
+	assert.Equal(tester.t, nexus.Spec.ServiceAccountName, d.Spec.Template.Spec.ServiceAccountName)
+	assert.Equal(tester.t, nexus.Spec.Image, d.Spec.Template.Spec.Containers[0].Image)
+	assert.True(tester.t, tester.containsJvmEnv(d))
+
+	if nexus.Spec.Persistence.Persistent {
+		assert.NotEmpty(tester.t, d.Spec.Template.Spec.Volumes)
+		assert.NotEmpty(tester.t, d.Spec.Template.Spec.Containers[0].VolumeMounts)
+	} else {
+		assert.Empty(tester.t, d.Spec.Template.Spec.Volumes)
+		assert.Empty(tester.t, d.Spec.Template.Spec.Containers[0].VolumeMounts)
+	}
+
+	// here we only check if the security context has been set as we don't want to couple the business logic (and the actual values) to this test
+	// testing the logic is up to the unit test
+	if nexus.Spec.UseRedHatImage {
+		assert.Nil(tester.t, d.Spec.Template.Spec.SecurityContext)
+	} else {
+		assert.NotNil(tester.t, d.Spec.Template.Spec.SecurityContext)
+	}
+
+	tester.checkDeploymentProbes(nexus, d)
+}
+
+func (tester *tester) containsJvmEnv(d *appsv1.Deployment) bool {
+	// here we only check if the parameters have been set as we don't want to couple the calculation logic to this test
+	// testing the logic is up to the unit test
+	for _, env := range d.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == deployment.JvmArgsEnvKey {
+			return true
+		}
+	}
+	return false
+}
+
+func (tester *tester) checkDeploymentProbes(nexus *v1alpha1.Nexus, d *appsv1.Deployment) {
+	assert.Equal(tester.t, nexus.Spec.LivenessProbe.FailureThreshold, d.Spec.Template.Spec.Containers[0].LivenessProbe.FailureThreshold)
+	assert.Equal(tester.t, nexus.Spec.LivenessProbe.PeriodSeconds, d.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds)
+	assert.Equal(tester.t, nexus.Spec.LivenessProbe.SuccessThreshold, d.Spec.Template.Spec.Containers[0].LivenessProbe.SuccessThreshold)
+	assert.Equal(tester.t, nexus.Spec.LivenessProbe.TimeoutSeconds, d.Spec.Template.Spec.Containers[0].LivenessProbe.TimeoutSeconds)
+	assert.Equal(tester.t, nexus.Spec.LivenessProbe.InitialDelaySeconds, d.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds)
+
+	assert.Equal(tester.t, nexus.Spec.ReadinessProbe.FailureThreshold, d.Spec.Template.Spec.Containers[0].ReadinessProbe.FailureThreshold)
+	assert.Equal(tester.t, nexus.Spec.ReadinessProbe.PeriodSeconds, d.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds)
+	assert.Equal(tester.t, nexus.Spec.ReadinessProbe.SuccessThreshold, d.Spec.Template.Spec.Containers[0].ReadinessProbe.SuccessThreshold)
+	assert.Equal(tester.t, nexus.Spec.ReadinessProbe.TimeoutSeconds, d.Spec.Template.Spec.Containers[0].ReadinessProbe.TimeoutSeconds)
+	assert.Equal(tester.t, nexus.Spec.ReadinessProbe.InitialDelaySeconds, d.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds)
+}
+
+func (tester *tester) checkServiceAccount(nexus *v1alpha1.Nexus) {
+	account := &corev1.ServiceAccount{}
+	err := tester.f.Client.Get(context.TODO(), types.NamespacedName{Name: nexus.Name, Namespace: nexus.Namespace}, account)
+	assert.Nil(tester.t, err)
+}
+
+func (tester *tester) checkIngress(nexus *v1alpha1.Nexus) {
+	if !nexus.Spec.Networking.Expose {
+		return
+	}
+
+	ingress := &v1beta1.Ingress{}
+	err := tester.f.Client.Get(context.TODO(), types.NamespacedName{Namespace: nexus.Namespace, Name: nexus.Name}, ingress)
+
+	if nexus.Spec.Networking.ExposeAs != v1alpha1.IngressExposeType {
+		assert.NotNil(tester.t, err)
+		assert.True(tester.t, errors.IsNotFound(err))
+		return
+	}
+
+	assert.Nil(tester.t, err)
+	assert.Equal(tester.t, nexus.Spec.Networking.Host, ingress.Spec.Rules[0].Host)
+	assert.True(tester.t, tester.ingressPointsToCorrectService(nexus, ingress))
+
+	if len(nexus.Spec.Networking.TLS.SecretName) > 0 {
+		assert.Equal(tester.t, nexus.Spec.Networking.TLS.SecretName, ingress.Spec.TLS[0].SecretName)
+		assert.Contains(tester.t, ingress.Spec.TLS[0].Hosts, nexus.Spec.Networking.Host)
+	}
+}
+
+func (tester *tester) ingressPointsToCorrectService(nexus *v1alpha1.Nexus, ingress *v1beta1.Ingress) bool {
+	for _, path := range ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths {
+		if path.Backend.ServiceName == nexus.Name {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Notable changes:

  - add networking E2E tests
  - add structured test case logic to allow the addition of test cases
  without deeper knowledge of what goes on in testing
  - add documentation about creating E2E tests
  - add an increased default timeout for the e2e tests (15m)

Fix #75 

Signed-off-by: Lucas Caparelli <lucas.caparelli112@gmail.com>