### PR TITLE
Allow the fake client to mock server API error responses

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,6 @@ coverage:
   status:
     project:
       operator:
-        target: 54
+        target: 58
         flags:
           - operator

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/RHsyseng/operator-utils v0.0.0-20200417223319-07e65f1aaddd
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.8
+	github.com/googleapis/gnostic v0.3.1
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/operator-framework/operator-sdk v0.18.1
 	github.com/spf13/pflag v1.0.5

--- a/pkg/framework/controller_watcher_test.go
+++ b/pkg/framework/controller_watcher_test.go
@@ -46,7 +46,7 @@ var requiredObjects = []WatchedObjects{
 
 // K8s < 3.14
 func Test_controllerWatcher_WatchWithoutIngressOnKubernetes(t *testing.T) {
-	cli := test.NewFakeDiscoveryClient().Build()
+	cli := test.NewFakeClientBuilder().Build()
 	controller := test.NewController()
 	manager := test.NewManager()
 
@@ -63,7 +63,7 @@ func Test_controllerWatcher_WatchWithoutIngressOnKubernetes(t *testing.T) {
 
 // K8s > 3.14
 func Test_controllerWatcher_WatchWithIngressOnKubernetes(t *testing.T) {
-	cli := test.NewFakeDiscoveryClient().WithIngress().Build()
+	cli := test.NewFakeClientBuilder().WithIngress().Build()
 	controller := test.NewController()
 	manager := test.NewManager()
 
@@ -80,7 +80,7 @@ func Test_controllerWatcher_WatchWithIngressOnKubernetes(t *testing.T) {
 
 // OCP
 func Test_controllerWatcher_WatchWithRouteOnOpenShift(t *testing.T) {
-	cli := test.NewFakeDiscoveryClient().OnOpenshift().Build()
+	cli := test.NewFakeClientBuilder().OnOpenshift().Build()
 	controller := test.NewController()
 	manager := test.NewManager()
 

--- a/pkg/test/client.go
+++ b/pkg/test/client.go
@@ -18,67 +18,270 @@
 package test
 
 import (
+	"context"
+	openapi_v2 "github.com/googleapis/gnostic/OpenAPIv2"
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
 	discfake "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	clienttesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const (
-	openshiftGroupVersion  = "openshift.io/v1"
-	monitoringGroupVersion = "monitoring.coreos.com/v1alpha1"
+	openshiftGroupVersion = "openshift.io/v1"
 )
 
-type FakeDiscBuilder struct {
-	*discfake.FakeDiscovery
+// FakeClientBuilder allows building a FakeClient according to
+// the desired cluster capabilities
+type FakeClientBuilder struct {
+	initObjs  []runtime.Object
+	scheme    *runtime.Scheme
+	resources []*metav1.APIResourceList
 }
 
-// NewFakeClient will create a new fake client with all needed schemas
-func NewFakeClient(initObjs ...runtime.Object) client.Client {
-	return fake.NewFakeClientWithScheme(GetSchema(), initObjs...)
-}
-
-// GetSchema gets the needed schema for fake tests
-func GetSchema() *runtime.Scheme {
+// NewFakeClientBuilder will create a new fake client that is aware of minimal resource types
+// and stores initObjs for initialization later
+func NewFakeClientBuilder(initObjs ...runtime.Object) *FakeClientBuilder {
 	s := scheme.Scheme
-	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.Nexus{})
-	s.AddKnownTypes(routev1.GroupVersion, &routev1.Route{}, &routev1.RouteList{})
-	return s
+	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.Nexus{}, &v1alpha1.NexusList{})
+
+	res := []*metav1.APIResourceList{{GroupVersion: v1alpha1.SchemeGroupVersion.String()}}
+
+	return &FakeClientBuilder{
+		initObjs:  initObjs,
+		scheme:    s,
+		resources: res,
+	}
 }
 
-// NewFakeDiscoveryClient creates a fake discovery client
-func NewFakeDiscoveryClient() *FakeDiscBuilder {
-	return &FakeDiscBuilder{&discfake.FakeDiscovery{
-		Fake: &clienttesting.Fake{
-			Resources: []*metav1.APIResourceList{
-				{GroupVersion: monitoringGroupVersion},
-			},
-		},
-	}}
-}
-
-// OnOpenshift sets Openshift related server groups to the fake discovery
-func (d *FakeDiscBuilder) OnOpenshift() *FakeDiscBuilder {
-	d.Fake.Resources = append(d.Fake.Resources,
+// OnOpenshift makes the fake client aware of resources from Openshift
+func (b *FakeClientBuilder) OnOpenshift() *FakeClientBuilder {
+	b.scheme.AddKnownTypes(routev1.GroupVersion, &routev1.Route{}, &routev1.RouteList{})
+	b.resources = append(b.resources,
 		&metav1.APIResourceList{GroupVersion: openshiftGroupVersion},
 		&metav1.APIResourceList{GroupVersion: routev1.GroupVersion.String()})
-	return d
+	return b
 }
 
-// WithIngress sets Ingress the server group to the fake discovery
-func (d *FakeDiscBuilder) WithIngress() *FakeDiscBuilder {
-	d.Fake.Resources = append(d.Fake.Resources, &metav1.APIResourceList{GroupVersion: v1beta1.SchemeGroupVersion.String()})
-	return d
+// WithIngress makes the fake client aware of Ingresses
+func (b *FakeClientBuilder) WithIngress() *FakeClientBuilder {
+	b.scheme.AddKnownTypes(v1beta1.SchemeGroupVersion, &v1beta1.Ingress{}, &v1beta1.IngressList{})
+	b.resources = append(b.resources, &metav1.APIResourceList{GroupVersion: v1beta1.SchemeGroupVersion.String()})
+	return b
 }
 
 // Build returns the fake discovery client
-func (d *FakeDiscBuilder) Build() discovery.DiscoveryInterface {
-	return d
+func (b *FakeClientBuilder) Build() *FakeClient {
+	c := &FakeClient{
+		client: fake.NewFakeClientWithScheme(b.scheme, b.initObjs...),
+		disc: &discfake.FakeDiscovery{
+			Fake: &clienttesting.Fake{
+				Resources: b.resources,
+			},
+		},
+	}
+	c.this = c
+	return c
+}
+
+// FakeClient wraps an API fake client to allow mocked error responses
+// Useful for covering errors other than NotFound
+// It also wraps a fake discovery client
+// FakeClient implements both client.Client and discovery.DiscoveryInterface
+type FakeClient struct {
+	client           client.Client
+	disc             discovery.DiscoveryInterface
+	mockErr          error
+	shouldClearError bool
+	// sometimes we need to call pointer receiver methods from value receiver methods
+	// we can't turn the value receivers into pointer receivers without breaking interfaces
+	// this allows us to always hold a reference to the original struct so we can modify it
+	this *FakeClient
+}
+
+// SetMockError sets the error which should be returned for the following requests
+// This error will continue to be served until cleared with c.ClearMockError()
+func (c *FakeClient) SetMockError(err error) {
+	c.shouldClearError = false
+	c.mockErr = err
+}
+
+// SetMockErrorForOneRequest sets the error which should be returned for the following request
+// this error will be set to nil after the next request
+func (c *FakeClient) SetMockErrorForOneRequest(err error) {
+	c.shouldClearError = true
+	c.mockErr = err
+}
+
+// ClearMockError unsets any mock errors previously set
+func (c *FakeClient) ClearMockError() {
+	c.shouldClearError = false
+	c.mockErr = nil
+}
+
+func (c FakeClient) RESTClient() rest.Interface {
+	return c.disc.RESTClient()
+}
+
+func (c FakeClient) ServerGroups() (*metav1.APIGroupList, error) {
+	if c.mockErr != nil {
+		if c.shouldClearError {
+			defer c.this.ClearMockError()
+		}
+		return nil, c.mockErr
+	}
+	return c.disc.ServerGroups()
+}
+
+func (c FakeClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	if c.mockErr != nil {
+		if c.shouldClearError {
+			defer c.this.ClearMockError()
+		}
+		return nil, c.mockErr
+	}
+	return c.disc.ServerResourcesForGroupVersion(groupVersion)
+}
+
+// Deprecated: use ServerGroupsAndResources instead.
+func (c FakeClient) ServerResources() ([]*metav1.APIResourceList, error) {
+	if c.mockErr != nil {
+		if c.shouldClearError {
+			defer c.this.ClearMockError()
+		}
+		return nil, c.mockErr
+	}
+	return c.disc.ServerResources()
+}
+
+func (c FakeClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	if c.mockErr != nil {
+		if c.shouldClearError {
+			defer c.this.ClearMockError()
+		}
+		return nil, nil, c.mockErr
+	}
+	return c.disc.ServerGroupsAndResources()
+}
+
+func (c FakeClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	if c.mockErr != nil {
+		if c.shouldClearError {
+			defer c.this.ClearMockError()
+		}
+		return nil, c.mockErr
+	}
+	return c.disc.ServerPreferredResources()
+}
+
+func (c FakeClient) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	if c.mockErr != nil {
+		if c.shouldClearError {
+			defer c.this.ClearMockError()
+		}
+		return nil, c.mockErr
+	}
+	return c.disc.ServerPreferredNamespacedResources()
+}
+
+func (c FakeClient) ServerVersion() (*version.Info, error) {
+	if c.mockErr != nil {
+		if c.shouldClearError {
+			defer c.this.ClearMockError()
+		}
+		return nil, c.mockErr
+	}
+	return c.disc.ServerVersion()
+}
+
+func (c FakeClient) OpenAPISchema() (*openapi_v2.Document, error) {
+	if c.mockErr != nil {
+		if c.shouldClearError {
+			defer c.this.ClearMockError()
+		}
+		return nil, c.mockErr
+	}
+	return c.disc.OpenAPISchema()
+}
+
+func (c FakeClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	if c.mockErr != nil {
+		if c.shouldClearError {
+			defer c.this.ClearMockError()
+		}
+		return c.mockErr
+	}
+	return c.client.Get(ctx, key, obj)
+}
+
+func (c FakeClient) List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+	if c.mockErr != nil {
+		if c.shouldClearError {
+			defer c.this.ClearMockError()
+		}
+		return c.mockErr
+	}
+	return c.client.List(ctx, list, opts...)
+}
+
+func (c FakeClient) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+	if c.mockErr != nil {
+		if c.shouldClearError {
+			defer c.this.ClearMockError()
+		}
+		return c.mockErr
+	}
+	return c.client.Create(ctx, obj, opts...)
+}
+
+func (c FakeClient) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+	if c.mockErr != nil {
+		if c.shouldClearError {
+			defer c.this.ClearMockError()
+		}
+		return c.mockErr
+	}
+	return c.client.Delete(ctx, obj, opts...)
+}
+
+func (c FakeClient) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	if c.mockErr != nil {
+		if c.shouldClearError {
+			defer c.this.ClearMockError()
+		}
+		return c.mockErr
+	}
+	return c.client.Update(ctx, obj, opts...)
+}
+
+func (c FakeClient) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if c.mockErr != nil {
+		if c.shouldClearError {
+			defer c.this.ClearMockError()
+		}
+		return c.mockErr
+	}
+	return c.client.Patch(ctx, obj, patch, opts...)
+}
+
+func (c FakeClient) DeleteAllOf(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error {
+	if c.mockErr != nil {
+		if c.shouldClearError {
+			defer c.this.ClearMockError()
+		}
+		return c.mockErr
+	}
+	return c.client.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (c FakeClient) Status() client.StatusWriter {
+	return c.client.Status()
 }

--- a/pkg/test/client_test.go
+++ b/pkg/test/client_test.go
@@ -1,0 +1,382 @@
+//     Copyright 2020 Nexus Operator and/or its authors
+//
+//     This file is part of Nexus Operator.
+//
+//     Nexus Operator is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Nexus Operator is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Nexus Operator.  If not, see <https://www.gnu.org/licenses/>.
+
+package test
+
+import (
+	ctx "context"
+	"fmt"
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/cluster/kubernetes"
+	"github.com/m88i/nexus-operator/pkg/cluster/openshift"
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/assert"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+	"testing"
+)
+
+const testErrorMsg = "test"
+
+func TestNewFakeClientBuilder(t *testing.T) {
+	nexus := &v1alpha1.Nexus{}
+	b := NewFakeClientBuilder(nexus)
+
+	// client.Client
+	assert.Len(t, b.scheme.KnownTypes(v1alpha1.SchemeGroupVersion), 2)
+	assert.Contains(t, b.scheme.KnownTypes(v1alpha1.SchemeGroupVersion), strings.Split(reflect.TypeOf(&v1alpha1.Nexus{}).String(), ".")[1])
+	assert.Contains(t, b.scheme.KnownTypes(v1alpha1.SchemeGroupVersion), strings.Split(reflect.TypeOf(&v1alpha1.NexusList{}).String(), ".")[1])
+
+	// discovery.DiscoveryInterface
+	assert.True(t, resourceListsContainsGroupVersion(b.resources, v1alpha1.SchemeGroupVersion.String()))
+
+	// initObjs
+	assert.Len(t, b.initObjs, 1)
+	assert.Contains(t, b.initObjs, nexus)
+}
+
+func TestFakeClientBuilder_OnOpenshift(t *testing.T) {
+	b := NewFakeClientBuilder().OnOpenshift()
+
+	// client.Client
+	assert.Len(t, b.scheme.KnownTypes(routev1.GroupVersion), 2)
+	assert.Contains(t, b.scheme.KnownTypes(routev1.GroupVersion), strings.Split(reflect.TypeOf(&routev1.Route{}).String(), ".")[1])
+	assert.Contains(t, b.scheme.KnownTypes(routev1.GroupVersion), strings.Split(reflect.TypeOf(&routev1.RouteList{}).String(), ".")[1])
+
+	// discovery.DiscoveryInterface
+	assert.True(t, resourceListsContainsGroupVersion(b.resources, routev1.GroupVersion.String()))
+	assert.True(t, resourceListsContainsGroupVersion(b.resources, openshiftGroupVersion))
+}
+
+func TestFakeClientBuilder_WithIngress(t *testing.T) {
+	b := NewFakeClientBuilder().WithIngress()
+
+	// client.Client
+	assert.Len(t, b.scheme.KnownTypes(networkingv1beta1.SchemeGroupVersion), 12)
+	assert.Contains(t, b.scheme.KnownTypes(networkingv1beta1.SchemeGroupVersion), strings.Split(reflect.TypeOf(&networkingv1beta1.Ingress{}).String(), ".")[1])
+	assert.Contains(t, b.scheme.KnownTypes(networkingv1beta1.SchemeGroupVersion), strings.Split(reflect.TypeOf(&networkingv1beta1.IngressList{}).String(), ".")[1])
+
+	// discovery.DiscoveryInterface
+	assert.True(t, resourceListsContainsGroupVersion(b.resources, networkingv1beta1.SchemeGroupVersion.String()))
+}
+
+func TestFakeClientBuilder_Build(t *testing.T) {
+	nexus := &v1alpha1.Nexus{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "nexus"}}
+	route := &routev1.Route{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "route"}}
+	ingress := &networkingv1beta1.Ingress{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "ingress"}}
+
+	b := NewFakeClientBuilder(nexus)
+	c := b.Build()
+	assert.Equal(t, c, c.this)
+	assert.NotNil(t, c.disc)
+	assert.NotNil(t, c.client)
+	assert.NoError(t, c.client.Get(ctx.TODO(), client.ObjectKey{
+		Namespace: nexus.Namespace,
+		Name:      nexus.Name,
+	}, nexus))
+	ocp, _ := openshift.IsOpenShift(c)
+	assert.False(t, ocp)
+	withRoute, _ := openshift.IsRouteAvailable(c)
+	assert.False(t, withRoute)
+	withIngress, _ := kubernetes.IsIngressAvailable(c)
+	assert.False(t, withIngress)
+
+	// on Openshift
+	b = NewFakeClientBuilder(nexus, route).OnOpenshift()
+	c = b.Build()
+	assert.NoError(t, c.client.Get(ctx.TODO(), client.ObjectKey{
+		Namespace: route.Namespace,
+		Name:      route.Name,
+	}, route))
+	ocp, _ = openshift.IsOpenShift(c)
+	assert.True(t, ocp)
+	withRoute, _ = openshift.IsRouteAvailable(c)
+	assert.True(t, withRoute)
+	withIngress, _ = kubernetes.IsIngressAvailable(c)
+	assert.False(t, withIngress)
+
+	// with Ingress
+	b = NewFakeClientBuilder(nexus, ingress).WithIngress()
+	c = b.Build()
+	assert.NoError(t, c.client.Get(ctx.TODO(), client.ObjectKey{
+		Namespace: ingress.Namespace,
+		Name:      ingress.Name,
+	}, ingress))
+	ocp, _ = openshift.IsOpenShift(c)
+	assert.False(t, ocp)
+	withRoute, _ = openshift.IsRouteAvailable(c)
+	assert.False(t, withRoute)
+	withIngress, _ = kubernetes.IsIngressAvailable(c)
+	assert.True(t, withIngress)
+}
+
+func resourceListsContainsGroupVersion(lists []*metav1.APIResourceList, gv string) bool {
+	for _, list := range lists {
+		if list.GroupVersion == gv {
+			return true
+		}
+	}
+	return false
+}
+
+func TestFakeClient_SetMockError(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	assert.Nil(t, c.mockErr)
+	assert.False(t, c.shouldClearError)
+	c.SetMockError(fmt.Errorf(testErrorMsg))
+	assert.Equal(t, c.mockErr.Error(), testErrorMsg)
+	assert.False(t, c.shouldClearError)
+}
+
+func TestFakeClient_SetMockErrorForOneRequest(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	assert.Nil(t, c.mockErr)
+	assert.False(t, c.shouldClearError)
+	c.SetMockErrorForOneRequest(fmt.Errorf(testErrorMsg))
+	assert.Equal(t, c.mockErr.Error(), testErrorMsg)
+	assert.True(t, c.shouldClearError)
+}
+
+func TestFakeClient_ClearMockError(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	assert.Nil(t, c.mockErr)
+	assert.False(t, c.shouldClearError)
+	c.SetMockErrorForOneRequest(fmt.Errorf(testErrorMsg))
+	assert.Equal(t, c.mockErr.Error(), testErrorMsg)
+	assert.True(t, c.shouldClearError)
+	c.ClearMockError()
+	assert.Nil(t, c.mockErr)
+	assert.False(t, c.shouldClearError)
+}
+
+func TestFakeClient_RESTClient(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	assert.Equal(t, c.disc.RESTClient(), c.RESTClient())
+}
+
+func TestFakeClient_ServerGroups(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	mockErr := fmt.Errorf(testErrorMsg)
+	c.SetMockErrorForOneRequest(mockErr)
+	_, err := c.ServerGroups()
+	assert.Equal(t, mockErr, err)
+
+	want, wantErr := c.disc.ServerGroups()
+	got, gotErr := c.ServerGroups()
+	assert.Equal(t, want, got)
+	assert.Equal(t, wantErr, gotErr)
+	assert.NotEqual(t, gotErr, mockErr)
+}
+
+func TestFakeClient_ServerResourcesForGroupVersion(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	mockErr := fmt.Errorf(testErrorMsg)
+	c.SetMockErrorForOneRequest(mockErr)
+	_, err := c.ServerResourcesForGroupVersion("")
+	assert.Equal(t, mockErr, err)
+
+	want, wantErr := c.disc.ServerResourcesForGroupVersion("")
+	got, gotErr := c.ServerResourcesForGroupVersion("")
+	assert.Equal(t, want, got)
+	assert.Equal(t, wantErr, gotErr)
+	assert.NotEqual(t, gotErr, mockErr)
+}
+
+// Deprecated: use ServerGroupsAndResources instead.
+func TestFakeClient_ServerResources(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	mockErr := fmt.Errorf(testErrorMsg)
+	c.SetMockErrorForOneRequest(mockErr)
+	_, err := c.ServerResources()
+	assert.Equal(t, mockErr, err)
+
+	want, wantErr := c.disc.ServerResources()
+	got, gotErr := c.ServerResources()
+	assert.Equal(t, want, got)
+	assert.Equal(t, wantErr, gotErr)
+	assert.NotEqual(t, gotErr, mockErr)
+}
+
+func TestFakeClient_ServerGroupsAndResources(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	mockErr := fmt.Errorf(testErrorMsg)
+	c.SetMockErrorForOneRequest(mockErr)
+	_, _, err := c.ServerGroupsAndResources()
+	assert.Equal(t, mockErr, err)
+
+	want1, want2, wantErr := c.disc.ServerGroupsAndResources()
+	got1, got2, gotErr := c.ServerGroupsAndResources()
+	assert.Equal(t, want1, got1)
+	assert.Equal(t, want2, got2)
+	assert.Equal(t, wantErr, gotErr)
+	assert.NotEqual(t, gotErr, mockErr)
+}
+
+func TestFakeClient_ServerPreferredResources(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	mockErr := fmt.Errorf(testErrorMsg)
+	c.SetMockErrorForOneRequest(mockErr)
+	_, err := c.ServerPreferredResources()
+	assert.Equal(t, mockErr, err)
+
+	want, wantErr := c.disc.ServerPreferredResources()
+	got, gotErr := c.ServerPreferredResources()
+	assert.Equal(t, want, got)
+	assert.Equal(t, wantErr, gotErr)
+	assert.NotEqual(t, gotErr, mockErr)
+}
+
+func TestFakeClient_ServerPreferredNamespacedResources(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	mockErr := fmt.Errorf(testErrorMsg)
+	c.SetMockErrorForOneRequest(mockErr)
+	_, err := c.ServerPreferredNamespacedResources()
+	assert.Equal(t, mockErr, err)
+
+	want, wantErr := c.disc.ServerPreferredNamespacedResources()
+	got, gotErr := c.ServerPreferredNamespacedResources()
+	assert.Equal(t, want, got)
+	assert.Equal(t, wantErr, gotErr)
+	assert.NotEqual(t, gotErr, mockErr)
+}
+
+func TestFakeClient_ServerVersion(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	mockErr := fmt.Errorf(testErrorMsg)
+	c.SetMockErrorForOneRequest(mockErr)
+	_, err := c.ServerVersion()
+	assert.Equal(t, mockErr, err)
+
+	want, wantErr := c.disc.ServerVersion()
+	got, gotErr := c.ServerVersion()
+	assert.Equal(t, want, got)
+	assert.Equal(t, wantErr, gotErr)
+	assert.NotEqual(t, gotErr, mockErr)
+}
+
+func TestFakeClient_OpenAPISchema(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	mockErr := fmt.Errorf(testErrorMsg)
+	c.SetMockErrorForOneRequest(mockErr)
+	_, err := c.OpenAPISchema()
+	assert.Equal(t, mockErr, err)
+
+	want, wantErr := c.disc.OpenAPISchema()
+	got, gotErr := c.OpenAPISchema()
+	assert.Equal(t, want, got)
+	assert.Equal(t, wantErr, gotErr)
+	assert.NotEqual(t, gotErr, mockErr)
+}
+
+func TestFakeClient_Get(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	mockErr := fmt.Errorf(testErrorMsg)
+	c.SetMockErrorForOneRequest(mockErr)
+	err := c.Get(ctx.TODO(), client.ObjectKey{}, &v1alpha1.Nexus{})
+	assert.Equal(t, mockErr, err)
+
+	want := c.client.Get(ctx.TODO(), client.ObjectKey{}, &v1alpha1.Nexus{})
+	got := c.Get(ctx.TODO(), client.ObjectKey{}, &v1alpha1.Nexus{})
+	assert.Equal(t, want, got)
+	assert.NotEqual(t, got, mockErr)
+}
+
+func TestFakeClient_List(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	mockErr := fmt.Errorf(testErrorMsg)
+	c.SetMockErrorForOneRequest(mockErr)
+	err := c.List(ctx.TODO(), &v1alpha1.NexusList{})
+	assert.Equal(t, mockErr, err)
+
+	want := c.client.List(ctx.TODO(), &v1alpha1.NexusList{})
+	got := c.List(ctx.TODO(), &v1alpha1.NexusList{})
+	assert.Equal(t, want, got)
+	assert.NotEqual(t, got, mockErr)
+}
+
+func TestFakeClient_Create(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	mockErr := fmt.Errorf(testErrorMsg)
+	c.SetMockErrorForOneRequest(mockErr)
+	err := c.Create(ctx.TODO(), &v1alpha1.Nexus{})
+	assert.Equal(t, mockErr, err)
+
+	want := c.client.Create(ctx.TODO(), &v1alpha1.Nexus{})
+	got := c.Create(ctx.TODO(), &v1alpha1.Nexus{})
+	assert.Equal(t, want, got)
+	assert.NotEqual(t, got, mockErr)
+}
+
+func TestFakeClient_Delete(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	mockErr := fmt.Errorf(testErrorMsg)
+	c.SetMockErrorForOneRequest(mockErr)
+	err := c.Delete(ctx.TODO(), &v1alpha1.Nexus{})
+	assert.Equal(t, mockErr, err)
+
+	want := c.client.Delete(ctx.TODO(), &v1alpha1.Nexus{})
+	got := c.Delete(ctx.TODO(), &v1alpha1.Nexus{})
+	assert.Equal(t, want, got)
+	assert.NotEqual(t, got, mockErr)
+}
+
+func TestFakeClient_Update(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	mockErr := fmt.Errorf(testErrorMsg)
+	c.SetMockErrorForOneRequest(mockErr)
+	err := c.Update(ctx.TODO(), &v1alpha1.Nexus{})
+	assert.Equal(t, mockErr, err)
+
+	want := c.client.Update(ctx.TODO(), &v1alpha1.Nexus{})
+	got := c.Update(ctx.TODO(), &v1alpha1.Nexus{})
+	assert.Equal(t, want, got)
+	assert.NotEqual(t, got, mockErr)
+}
+
+func TestFakeClient_Patch(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	mockErr := fmt.Errorf(testErrorMsg)
+	c.SetMockErrorForOneRequest(mockErr)
+	err := c.Patch(ctx.TODO(), &v1alpha1.Nexus{}, client.MergeFrom(&v1alpha1.Nexus{}))
+	assert.Equal(t, mockErr, err)
+
+	want := c.Patch(ctx.TODO(), &v1alpha1.Nexus{}, client.MergeFrom(&v1alpha1.Nexus{}))
+	got := c.Patch(ctx.TODO(), &v1alpha1.Nexus{}, client.MergeFrom(&v1alpha1.Nexus{}))
+	assert.Equal(t, want, got)
+	assert.NotEqual(t, got, mockErr)
+}
+
+func TestFakeClient_DeleteAllOf(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	mockErr := fmt.Errorf(testErrorMsg)
+	c.SetMockErrorForOneRequest(mockErr)
+	err := c.DeleteAllOf(ctx.TODO(), &v1alpha1.Nexus{})
+	assert.Equal(t, mockErr, err)
+
+	want := c.client.DeleteAllOf(ctx.TODO(), &v1alpha1.Nexus{})
+	got := c.DeleteAllOf(ctx.TODO(), &v1alpha1.Nexus{})
+	assert.Equal(t, want, got)
+	assert.NotEqual(t, got, mockErr)
+}
+
+func TestFakeClient_Status(t *testing.T) {
+	c := NewFakeClientBuilder().Build()
+	assert.Equal(t, c.client.Status(), c.Status())
+}

--- a/pkg/test/client_test.go
+++ b/pkg/test/client_test.go
@@ -40,7 +40,7 @@ func TestNewFakeClientBuilder(t *testing.T) {
 	b := NewFakeClientBuilder(nexus)
 
 	// client.Client
-	assert.Len(t, b.scheme.KnownTypes(v1alpha1.SchemeGroupVersion), 2)
+	assert.Len(t, b.scheme.KnownTypes(v1alpha1.SchemeGroupVersion), 10)
 	assert.Contains(t, b.scheme.KnownTypes(v1alpha1.SchemeGroupVersion), strings.Split(reflect.TypeOf(&v1alpha1.Nexus{}).String(), ".")[1])
 	assert.Contains(t, b.scheme.KnownTypes(v1alpha1.SchemeGroupVersion), strings.Split(reflect.TypeOf(&v1alpha1.NexusList{}).String(), ".")[1])
 
@@ -56,7 +56,7 @@ func TestFakeClientBuilder_OnOpenshift(t *testing.T) {
 	b := NewFakeClientBuilder().OnOpenshift()
 
 	// client.Client
-	assert.Len(t, b.scheme.KnownTypes(routev1.GroupVersion), 2)
+	assert.Len(t, b.scheme.KnownTypes(routev1.GroupVersion), 10)
 	assert.Contains(t, b.scheme.KnownTypes(routev1.GroupVersion), strings.Split(reflect.TypeOf(&routev1.Route{}).String(), ".")[1])
 	assert.Contains(t, b.scheme.KnownTypes(routev1.GroupVersion), strings.Split(reflect.TypeOf(&routev1.RouteList{}).String(), ".")[1])
 

--- a/pkg/util/error.go
+++ b/pkg/util/error.go
@@ -1,0 +1,25 @@
+//     Copyright 2020 Nexus Operator and/or its authors
+//
+//     This file is part of Nexus Operator.
+//
+//     Nexus Operator is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Nexus Operator is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Nexus Operator.  If not, see <https://www.gnu.org/licenses/>.
+
+package util
+
+// Must panics on non-nil errors.
+func Must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Encapsulate the fake API and discovery clients in a single struct
capable of mocking error responses that implements both relevant
interfaces ([client.Client](https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/client/interfaces.go#L104) and [discovery.DiscoveryInterface](https://github.com/kubernetes/client-go/blob/master/discovery/discovery_client.go#L55)).

Fix #105 

Signed-off-by: Lucas Caparelli <lucas.caparelli112@gmail.com>