### PR TITLE
Refactor resource managers to return their struct, not the interface

### DIFF
--- a/pkg/controller/nexus/nexus_controller.go
+++ b/pkg/controller/nexus/nexus_controller.go
@@ -20,7 +20,6 @@ package nexus
 import (
 	"context"
 	"fmt"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/infra"
 	"reflect"
 
 	"github.com/m88i/nexus-operator/pkg/cluster/kubernetes"
@@ -115,7 +114,7 @@ type ReconcileNexus struct {
 	client             client.Client
 	scheme             *runtime.Scheme
 	discoveryClient    discovery.DiscoveryInterface
-	resourceSupervisor infra.Supervisor
+	resourceSupervisor resource.Supervisor
 }
 
 // Reconcile reads that state of the cluster for a Nexus object and makes changes based on the state read

--- a/pkg/controller/nexus/resource/deployment/manager_test.go
+++ b/pkg/controller/nexus/resource/deployment/manager_test.go
@@ -130,7 +130,7 @@ func TestNewManager_setDefaults(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		manager := &manager{
+		manager := &Manager{
 			nexus: tt.input,
 		}
 		manager.setDefaults()

--- a/pkg/controller/nexus/resource/interfaces.go
+++ b/pkg/controller/nexus/resource/interfaces.go
@@ -15,7 +15,7 @@
 //     You should have received a copy of the GNU General Public License
 //     along with Nexus Operator.  If not, see <https://www.gnu.org/licenses/>.
 
-package infra
+package resource
 
 import (
 	"github.com/RHsyseng/operator-utils/pkg/resource"

--- a/pkg/controller/nexus/resource/networking/manager_test.go
+++ b/pkg/controller/nexus/resource/networking/manager_test.go
@@ -123,7 +123,7 @@ func TestManager_validate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		manager := &manager{
+		manager := &Manager{
 			nexus:            &tt.input,
 			routeAvailable:   tt.routeAvailable,
 			ingressAvailable: tt.ingressAvailable,
@@ -171,7 +171,7 @@ func TestNewManager_setDefaults(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		manager := &manager{
+		manager := &Manager{
 			nexus:            &tt.input,
 			routeAvailable:   tt.routeAvailable,
 			ingressAvailable: tt.ingressAvailable,

--- a/pkg/controller/nexus/resource/networking/manager_test.go
+++ b/pkg/controller/nexus/resource/networking/manager_test.go
@@ -19,9 +19,45 @@ package networking
 
 import (
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/test"
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 )
+
+func TestManager_IngressAvailable(t *testing.T) {
+	// let's try without correctly creating a manager first
+	mgr := &Manager{}
+	_, err := mgr.IngressAvailable()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), mgrNotInit)
+
+	// now with a proper manager
+	client := test.NewFakeClientBuilder().Build()
+	nexus := v1alpha1.Nexus{}
+	mgr, err = NewManager(nexus, client, client)
+	assert.Nil(t, err)
+	available, err := mgr.IngressAvailable()
+	assert.Nil(t, err)
+	assert.Equal(t, mgr.ingressAvailable, available)
+}
+
+func TestManager_RouteAvailable(t *testing.T) {
+	// let's try without correctly creating a manager first
+	mgr := &Manager{}
+	_, err := mgr.RouteAvailable()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), mgrNotInit)
+
+	// now with a proper manager
+	client := test.NewFakeClientBuilder().Build()
+	nexus := v1alpha1.Nexus{}
+	mgr, err = NewManager(nexus, client, client)
+	assert.Nil(t, err)
+	available, err := mgr.RouteAvailable()
+	assert.Nil(t, err)
+	assert.Equal(t, mgr.ingressAvailable, available)
+}
 
 func TestManager_validate(t *testing.T) {
 	tests := []struct {

--- a/pkg/controller/nexus/resource/persistence/manager.go
+++ b/pkg/controller/nexus/resource/persistence/manager.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"github.com/RHsyseng/operator-utils/pkg/resource"
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/infra"
 	"github.com/m88i/nexus-operator/pkg/logger"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -39,14 +38,14 @@ const (
 var log = logger.GetLogger("persistence_manager")
 
 // manager is responsible for creating persistence resources, fetching deployed ones and comparing them
-type manager struct {
+type Manager struct {
 	nexus  *v1alpha1.Nexus
 	client client.Client
 }
 
 // NewManager creates a persistence resources manager
-func NewManager(nexus v1alpha1.Nexus, client client.Client) infra.Manager {
-	mgr := &manager{
+func NewManager(nexus v1alpha1.Nexus, client client.Client) *Manager {
+	mgr := &Manager{
 		nexus:  &nexus,
 		client: client,
 	}
@@ -55,14 +54,18 @@ func NewManager(nexus v1alpha1.Nexus, client client.Client) infra.Manager {
 }
 
 // setDefaults destructively sets default for unset values in the Nexus CR
-func (m *manager) setDefaults() {
+func (m *Manager) setDefaults() {
 	if m.nexus.Spec.Persistence.Persistent && len(m.nexus.Spec.Persistence.VolumeSize) == 0 {
 		m.nexus.Spec.Persistence.VolumeSize = defaultVolumeSize
 	}
 }
 
 // GetRequiredResources returns the resources initialized by the manager
-func (m *manager) GetRequiredResources() ([]resource.KubernetesResource, error) {
+func (m *Manager) GetRequiredResources() ([]resource.KubernetesResource, error) {
+	if m.nexus == nil || m.client == nil {
+		return nil, fmt.Errorf(mgrNotInit)
+	}
+
 	var resources []resource.KubernetesResource
 	if m.nexus.Spec.Persistence.Persistent {
 		log.Debugf("Creating Persistent Volume Claim (%s)", m.nexus.Name)
@@ -73,7 +76,7 @@ func (m *manager) GetRequiredResources() ([]resource.KubernetesResource, error) 
 }
 
 // GetDeployedResources returns the persistence resources deployed on the cluster
-func (m *manager) GetDeployedResources() ([]resource.KubernetesResource, error) {
+func (m *Manager) GetDeployedResources() ([]resource.KubernetesResource, error) {
 	if m.nexus == nil || m.client == nil {
 		return nil, fmt.Errorf(mgrNotInit)
 	}
@@ -88,7 +91,7 @@ func (m *manager) GetDeployedResources() ([]resource.KubernetesResource, error) 
 	return resources, nil
 }
 
-func (m *manager) getDeployedPVC() (resource.KubernetesResource, error) {
+func (m *Manager) getDeployedPVC() (resource.KubernetesResource, error) {
 	pvc := &corev1.PersistentVolumeClaim{}
 	key := types.NamespacedName{Namespace: m.nexus.Namespace, Name: m.nexus.Name}
 	log.Debugf("Attempting to fetch deployed Persistent Volume Claim (%s)", m.nexus.Name)
@@ -104,14 +107,14 @@ func (m *manager) getDeployedPVC() (resource.KubernetesResource, error) {
 
 // GetCustomComparator returns the custom comp function used to compare a persistence resource.
 // Returns nil if there is none
-func (m *manager) GetCustomComparator(t reflect.Type) func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+func (m *Manager) GetCustomComparator(t reflect.Type) func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
 	// As PVCs have a default comparator we just return nil here
 	return nil
 }
 
 // GetCustomComparators returns all custom comp functions in a map indexed by the resource type
 // Returns nil if there are none
-func (m *manager) GetCustomComparators() map[reflect.Type]func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+func (m *Manager) GetCustomComparators() map[reflect.Type]func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
 	// As PVCs have a default comparator we just return nil here
 	return nil
 }

--- a/pkg/controller/nexus/resource/persistence/manager_test.go
+++ b/pkg/controller/nexus/resource/persistence/manager_test.go
@@ -37,7 +37,7 @@ func TestNewManager_setDefaults(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		manager := &manager{
+		manager := &Manager{
 			nexus: tt.input,
 		}
 		manager.setDefaults()

--- a/pkg/controller/nexus/resource/resources.go
+++ b/pkg/controller/nexus/resource/resources.go
@@ -19,8 +19,6 @@ package resource
 
 import (
 	"fmt"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/infra"
-
 	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/networking"
@@ -42,11 +40,11 @@ const mgrsNotInit = "resource managers have not been initialized"
 type supervisor struct {
 	client          client.Client
 	discoveryClient discovery.DiscoveryInterface
-	managers        []infra.Manager
+	managers        []Manager
 }
 
 // NewSupervisor creates a new resource manager for nexus CR
-func NewSupervisor(client client.Client, discoveryClient discovery.DiscoveryInterface) infra.Supervisor {
+func NewSupervisor(client client.Client, discoveryClient discovery.DiscoveryInterface) Supervisor {
 	return &supervisor{
 		client:          client,
 		discoveryClient: discoveryClient,
@@ -60,7 +58,7 @@ func (r *supervisor) InitManagers(nexus *v1alpha1.Nexus) error {
 		return fmt.Errorf("unable to create networking manager: %v", err)
 	}
 
-	r.managers = []infra.Manager{
+	r.managers = []Manager{
 		deployment.NewManager(*nexus, r.client),
 		persistence.NewManager(*nexus, r.client),
 		security.NewManager(*nexus, r.client),


### PR DESCRIPTION
Returning an interface can reduce the code's flexibility by removing all
of the object's behavior that's not explicitly defined in the interface.
By returning a struct instead, we leave it up to the caller to decide
how the return should be used.

Most notable changes:
  - Return the actual resource `Manager` structs instead of their interface
  - Expand on the networking manager's API to provide convenient means for
  users to determine if ingresses and routes are available.
  - Move resource `Supervisor` and `Manager` interfaces back to the 
  `resource` package as there is no longer a dependency cycle caused by 
  their presence there

Fix #109