### PR TITLE
Remove unnecessary nil checks on unexposed methods

### DIFF
--- a/pkg/controller/nexus/resource/networking/ingress.go
+++ b/pkg/controller/nexus/resource/networking/ingress.go
@@ -18,7 +18,6 @@
 package networking
 
 import (
-	"fmt"
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
@@ -28,13 +27,11 @@ import (
 
 const (
 	ingressBasePath = "/"
-	ingressNotInit  = "ingress builder not initialized"
 )
 
 type ingressBuilder struct {
-	ingress *v1beta1.Ingress
-	err     error
-	nexus   *v1alpha1.Nexus
+	*v1beta1.Ingress
+	nexus *v1alpha1.Nexus
 }
 
 func newIngressBuilder(nexus *v1alpha1.Nexus) *ingressBuilder {
@@ -60,43 +57,26 @@ func newIngressBuilder(nexus *v1alpha1.Nexus) *ingressBuilder {
 		},
 	}
 
-	return &ingressBuilder{
-		ingress: ingress,
-		err:     nil,
-		nexus:   nexus,
-	}
+	return &ingressBuilder{Ingress: ingress, nexus: nexus}
 }
 
 func (i *ingressBuilder) withCustomTLS() *ingressBuilder {
-	if i == nil {
-		i.err = fmt.Errorf(ingressNotInit)
-		return i
-	}
-
-	i.ingress.Spec.TLS = []v1beta1.IngressTLS{
+	i.Spec.TLS = []v1beta1.IngressTLS{
 		{
-			Hosts:      hosts(i.ingress),
+			Hosts:      hosts(i.Spec.Rules),
 			SecretName: i.nexus.Spec.Networking.TLS.SecretName,
 		},
 	}
 	return i
 }
 
-func (i *ingressBuilder) build() (*v1beta1.Ingress, error) {
-	if i == nil {
-		return nil, fmt.Errorf(ingressNotInit)
-	}
-
-	if i.err != nil {
-		return nil, i.err
-	}
-
-	return i.ingress, nil
+func (i *ingressBuilder) build() *v1beta1.Ingress {
+	return i.Ingress
 }
 
-func hosts(ingress *v1beta1.Ingress) []string {
+func hosts(rules []v1beta1.IngressRule) []string {
 	var hosts []string
-	for _, rule := range ingress.Spec.Rules {
+	for _, rule := range rules {
 		hosts = append(hosts, rule.Host)
 	}
 	return hosts

--- a/pkg/controller/nexus/resource/networking/ingress_test.go
+++ b/pkg/controller/nexus/resource/networking/ingress_test.go
@@ -64,31 +64,29 @@ func TestHosts(t *testing.T) {
 		},
 	}
 
-	h := hosts(ingress)
+	h := hosts(ingress.Spec.Rules)
 	assert.Len(t, h, 0)
 
 	host := "a"
 	ingress.Spec.Rules = append(ingress.Spec.Rules, v1beta1.IngressRule{Host: host})
-	h = hosts(ingress)
+	h = hosts(ingress.Spec.Rules)
 	assert.Len(t, h, 1)
 	assert.Equal(t, h[0], host)
 
 	host = "b"
 	ingress.Spec.Rules = append(ingress.Spec.Rules, v1beta1.IngressRule{Host: host})
-	h = hosts(ingress)
+	h = hosts(ingress.Spec.Rules)
 	assert.Len(t, h, 2)
 	assert.Equal(t, h[1], host)
 }
 
 func TestNewIngress(t *testing.T) {
-	ingress, err := newIngressBuilder(ingressNexus).build()
-	assert.Nil(t, err)
+	ingress := newIngressBuilder(ingressNexus).build()
 	assertIngressBasic(t, ingress)
 }
 
 func TestNewIngressWithSecretName(t *testing.T) {
-	ingress, err := newIngressBuilder(ingressNexus).withCustomTLS().build()
-	assert.Nil(t, err)
+	ingress := newIngressBuilder(ingressNexus).withCustomTLS().build()
 	assertIngressBasic(t, ingress)
 	assertIngressSecretName(t, ingress)
 }

--- a/pkg/controller/nexus/resource/networking/manager.go
+++ b/pkg/controller/nexus/resource/networking/manager.go
@@ -167,7 +167,6 @@ func (m *Manager) GetRequiredResources() ([]resource.KubernetesResource, error) 
 	if m.nexus == nil || m.client == nil {
 		return nil, fmt.Errorf(mgrNotInit)
 	}
-
 	if !m.nexus.Spec.Networking.Expose {
 		return nil, nil
 	}
@@ -180,11 +179,7 @@ func (m *Manager) GetRequiredResources() ([]resource.KubernetesResource, error) 
 		}
 
 		log.Debugf("Creating Route (%s)", m.nexus.Name)
-		route, err := m.createRoute()
-		if err != nil {
-			log.Errorf("Could not create Route: %v", err)
-			return nil, fmt.Errorf("could not create route: %v", err)
-		}
+		route := m.createRoute()
 		resources = append(resources, route)
 
 	case v1alpha1.IngressExposeType:
@@ -193,17 +188,13 @@ func (m *Manager) GetRequiredResources() ([]resource.KubernetesResource, error) 
 		}
 
 		log.Debugf("Creating Ingress (%s)", m.nexus.Name)
-		ingress, err := m.createIngress()
-		if err != nil {
-			log.Errorf("Could not create Ingress: %v", err)
-			return nil, fmt.Errorf("could not create ingress: %v", err)
-		}
+		ingress := m.createIngress()
 		resources = append(resources, ingress)
 	}
 	return resources, nil
 }
 
-func (m *Manager) createRoute() (*routev1.Route, error) {
+func (m *Manager) createRoute() *routev1.Route {
 	builder := newRouteBuilder(m.nexus)
 	if m.nexus.Spec.Networking.TLS.Mandatory {
 		builder = builder.withRedirect()
@@ -211,7 +202,7 @@ func (m *Manager) createRoute() (*routev1.Route, error) {
 	return builder.build()
 }
 
-func (m *Manager) createIngress() (*networkingv1beta1.Ingress, error) {
+func (m *Manager) createIngress() *networkingv1beta1.Ingress {
 	builder := newIngressBuilder(m.nexus)
 	if len(m.nexus.Spec.Networking.TLS.SecretName) > 0 {
 		builder = builder.withCustomTLS()

--- a/pkg/controller/nexus/resource/networking/route.go
+++ b/pkg/controller/nexus/resource/networking/route.go
@@ -18,8 +18,8 @@
 package networking
 
 import (
-	"fmt"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
@@ -27,14 +27,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-const (
-	serviceKind  = "Service"
-	routeNotInit = "route builder not initialized"
-)
+var serviceKind = (&corev1.Service{}).GroupVersionKind().Kind
 
 type routeBuilder struct {
-	route *v1.Route
-	err   error
+	*v1.Route
 }
 
 func newRouteBuilder(nexus *v1alpha1.Nexus) *routeBuilder {
@@ -50,22 +46,17 @@ func newRouteBuilder(nexus *v1alpha1.Nexus) *routeBuilder {
 			},
 		},
 	}
-	return &routeBuilder{route: route}
+	return &routeBuilder{route}
 }
 
 func (r *routeBuilder) withRedirect() *routeBuilder {
-	if r == nil {
-		r.err = fmt.Errorf(routeNotInit)
-		return r
-	}
-
-	r.route.Spec.TLS = &v1.TLSConfig{
+	r.Spec.TLS = &v1.TLSConfig{
 		Termination:                   v1.TLSTerminationEdge,
 		InsecureEdgeTerminationPolicy: v1.InsecureEdgeTerminationPolicyRedirect,
 	}
 	return r
 }
 
-func (r *routeBuilder) build() (*v1.Route, error) {
-	return r.route, r.err
+func (r *routeBuilder) build() *v1.Route {
+	return r.Route
 }

--- a/pkg/controller/nexus/resource/networking/route_test.go
+++ b/pkg/controller/nexus/resource/networking/route_test.go
@@ -59,14 +59,12 @@ var (
 )
 
 func TestNewRoute(t *testing.T) {
-	route, err := newRouteBuilder(routeNexus).build()
-	assert.Nil(t, err)
+	route := newRouteBuilder(routeNexus).build()
 	assertRouteBasic(t, route)
 }
 
 func TestNewRouteWithRedirection(t *testing.T) {
-	route, err := newRouteBuilder(routeNexus).withRedirect().build()
-	assert.Nil(t, err)
+	route := newRouteBuilder(routeNexus).withRedirect().build()
 	assertRouteBasic(t, route)
 	assertRouteRedirection(t, route)
 }

--- a/pkg/controller/nexus/resource/security/manager.go
+++ b/pkg/controller/nexus/resource/security/manager.go
@@ -57,12 +57,6 @@ func (m *Manager) setDefaults() {
 	}
 }
 
-type Script string
-type ScriptRepository interface {
-	Scripts() ([]Script, error)
-	ScriptByID(id int) (Script, error)
-}
-
 // GetRequiredResources returns the resources initialized by the Manager
 func (m *Manager) GetRequiredResources() ([]resource.KubernetesResource, error) {
 	if m.nexus == nil || m.client == nil {


### PR DESCRIPTION
These nil checks end up only masking existing bugs as the program would
not recover from them anyway. Removing them allows for simpler code.

Fix #111

Signed-off-by: Lucas Caparelli <lucas.caparelli112@gmail.com>