### PR TITLE
Let incorrect usage of the exposed API panic

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,5 +8,6 @@ coverage:
       operator:
         target: auto
         threshold: 5%
+        base: auto
         flags:
           - operator

--- a/pkg/controller/nexus/resource/deployment/manager.go
+++ b/pkg/controller/nexus/resource/deployment/manager.go
@@ -36,7 +36,6 @@ import (
 const (
 	NexusCommunityLatestImage       = "docker.io/sonatype/nexus3:latest"
 	NexusCertifiedLatestImage       = "registry.connect.redhat.com/sonatype/nexus-repository-manager"
-	mgrNotInit                      = "the manager has not been initialized"
 	probeDefaultInitialDelaySeconds = int32(240)
 	probeDefaultTimeoutSeconds      = int32(15)
 	probeDefaultPeriodSeconds       = int32(10)
@@ -68,6 +67,7 @@ var (
 )
 
 // Manager is responsible for creating deployment-related resources, fetching deployed ones and comparing them
+// Use with zero values will result in a panic. Use the NewManager function to get a properly initialized manager
 type Manager struct {
 	nexus  *v1alpha1.Nexus
 	client client.Client
@@ -158,10 +158,6 @@ func (m *Manager) setProbeDefaults() {
 
 // GetRequiredResources returns the resources initialized by the manager
 func (m *Manager) GetRequiredResources() ([]resource.KubernetesResource, error) {
-	if m.nexus == nil || m.client == nil {
-		return nil, fmt.Errorf(mgrNotInit)
-	}
-
 	log.Debugf("Creating Deployment (%s)", m.nexus.Name)
 	deployment := newDeployment(m.nexus)
 	log.Debugf("Creating Service (%s)", m.nexus.Name)
@@ -171,10 +167,6 @@ func (m *Manager) GetRequiredResources() ([]resource.KubernetesResource, error) 
 
 // GetDeployedResources returns the deployment-related resources deployed on the cluster
 func (m *Manager) GetDeployedResources() ([]resource.KubernetesResource, error) {
-	if m.nexus == nil || m.client == nil {
-		return nil, fmt.Errorf(mgrNotInit)
-	}
-
 	var resources []resource.KubernetesResource
 	if deployment, err := m.getDeployedDeployment(); err == nil {
 		resources = append(resources, deployment)

--- a/pkg/controller/nexus/resource/deployment/manager_test.go
+++ b/pkg/controller/nexus/resource/deployment/manager_test.go
@@ -178,19 +178,13 @@ func TestManager_setDefaults(t *testing.T) {
 }
 
 func TestManager_GetRequiredResources(t *testing.T) {
-	// first, let's test with mgr that has not been init
-	mgr := &Manager{}
-	resources, err := mgr.GetDeployedResources()
-	assert.Nil(t, resources)
-	assert.EqualError(t, err, mgrNotInit)
-
 	// correctness of the generated resources is tested elsewhere
 	// here we just want to check if they have been created and returned
-	mgr = &Manager{
+	mgr := &Manager{
 		nexus:  allDefaultsCommunityNexus,
 		client: test.NewFakeClientBuilder().Build(),
 	}
-	resources, err = mgr.GetRequiredResources()
+	resources, err := mgr.GetRequiredResources()
 	assert.Nil(t, err)
 	// a deployment and a service are _always_ created, so both should always be present
 	assert.Len(t, resources, 2)
@@ -199,24 +193,18 @@ func TestManager_GetRequiredResources(t *testing.T) {
 }
 
 func TestManager_GetDeployedResources(t *testing.T) {
-	// first, let's test with mgr that has not been init
-	mgr := &Manager{}
-	resources, err := mgr.GetDeployedResources()
-	assert.Nil(t, resources)
-	assert.EqualError(t, err, mgrNotInit)
-
-	// now a valid mgr, but no deployed resources
+	// first no deployed resources
 	fakeClient := test.NewFakeClientBuilder().Build()
-	mgr = &Manager{
+	mgr := &Manager{
 		nexus:  allDefaultsCommunityNexus,
 		client: fakeClient,
 	}
-	resources, err = mgr.GetDeployedResources()
+	resources, err := mgr.GetDeployedResources()
 	assert.Nil(t, resources)
 	assert.Len(t, resources, 0)
 	assert.NoError(t, err)
 
-	// now a valid mgr with deployed resources
+	// now with deployed resources
 	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: mgr.nexus.Name, Namespace: mgr.nexus.Namespace}}
 	assert.NoError(t, mgr.client.Create(ctx.TODO(), deployment))
 

--- a/pkg/controller/nexus/resource/networking/manager_test.go
+++ b/pkg/controller/nexus/resource/networking/manager_test.go
@@ -41,37 +41,21 @@ var nodePortNexus = &v1alpha1.Nexus{
 }
 
 func TestManager_IngressAvailable(t *testing.T) {
-	// let's try without correctly creating a manager first
-	mgr := &Manager{}
-	_, err := mgr.IngressAvailable()
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), mgrNotInit)
-
-	// now with a proper manager
 	client := test.NewFakeClientBuilder().Build()
 	nexus := v1alpha1.Nexus{}
-	mgr, err = NewManager(nexus, client, client)
+	mgr, err := NewManager(nexus, client, client)
 	assert.Nil(t, err)
-	available, err := mgr.IngressAvailable()
-	assert.Nil(t, err)
-	assert.Equal(t, mgr.ingressAvailable, available)
+
+	assert.Equal(t, mgr.ingressAvailable, mgr.IngressAvailable())
 }
 
 func TestManager_RouteAvailable(t *testing.T) {
-	// let's try without correctly creating a manager first
-	mgr := &Manager{}
-	_, err := mgr.RouteAvailable()
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), mgrNotInit)
-
-	// now with a proper manager
 	client := test.NewFakeClientBuilder().Build()
 	nexus := v1alpha1.Nexus{}
-	mgr, err = NewManager(nexus, client, client)
+	mgr, err := NewManager(nexus, client, client)
 	assert.Nil(t, err)
-	available, err := mgr.RouteAvailable()
-	assert.Nil(t, err)
-	assert.Equal(t, mgr.ingressAvailable, available)
+
+	assert.Equal(t, mgr.ingressAvailable, mgr.IngressAvailable())
 }
 
 func TestNewManager(t *testing.T) {
@@ -330,20 +314,14 @@ func TestManager_validate(t *testing.T) {
 }
 
 func TestManager_GetRequiredResources(t *testing.T) {
-	// first, let's test with mgr that has not been init
-	mgr := &Manager{}
-	resources, err := mgr.GetRequiredResources()
-	assert.Nil(t, resources)
-	assert.EqualError(t, err, mgrNotInit)
-
 	// correctness of the generated resources is tested elsewhere
 	// here we just want to check if they have been created and returned
 	// first, let's test a Nexus which does not expose
-	mgr = &Manager{
+	mgr := &Manager{
 		nexus:  &v1alpha1.Nexus{Spec: v1alpha1.NexusSpec{Networking: v1alpha1.NexusNetworking{Expose: false}}},
 		client: test.NewFakeClientBuilder().Build(),
 	}
-	resources, err = mgr.GetRequiredResources()
+	resources, err := mgr.GetRequiredResources()
 	assert.Nil(t, resources)
 	assert.Nil(t, err)
 
@@ -416,27 +394,21 @@ func TestManager_createIngress(t *testing.T) {
 }
 
 func TestManager_GetDeployedResources(t *testing.T) {
-	// first, let's test with mgr that has not been init
-	mgr := &Manager{}
-	resources, err := mgr.GetDeployedResources()
-	assert.Nil(t, resources)
-	assert.EqualError(t, err, mgrNotInit)
-
-	// now a valid mgr, but no deployed resources
+	// first with no deployed resources
 	fakeClient := test.NewFakeClientBuilder().WithIngress().OnOpenshift().Build()
-	mgr = &Manager{
+	mgr := &Manager{
 		nexus:            nodePortNexus,
 		client:           fakeClient,
 		ingressAvailable: true,
 		routeAvailable:   true,
 		ocp:              true,
 	}
-	resources, err = mgr.GetDeployedResources()
+	resources, err := mgr.GetDeployedResources()
 	assert.Nil(t, resources)
 	assert.Len(t, resources, 0)
 	assert.NoError(t, err)
 
-	// now a valid mgr with deployed resources
+	// now with deployed resources
 	route := &routev1.Route{ObjectMeta: metav1.ObjectMeta{Name: mgr.nexus.Name, Namespace: mgr.nexus.Namespace}}
 	assert.NoError(t, mgr.client.Create(ctx.TODO(), route))
 

--- a/pkg/controller/nexus/resource/persistence/manager.go
+++ b/pkg/controller/nexus/resource/persistence/manager.go
@@ -32,12 +32,12 @@ import (
 
 const (
 	defaultVolumeSize = "10Gi"
-	mgrNotInit        = "the manager has not been initialized"
 )
 
 var log = logger.GetLogger("persistence_manager")
 
-// manager is responsible for creating persistence resources, fetching deployed ones and comparing them
+// Manager is responsible for creating persistence resources, fetching deployed ones and comparing them
+// Use with zero values will result in a panic. Use the NewManager function to get a properly initialized manager
 type Manager struct {
 	nexus  *v1alpha1.Nexus
 	client client.Client
@@ -62,10 +62,6 @@ func (m *Manager) setDefaults() {
 
 // GetRequiredResources returns the resources initialized by the manager
 func (m *Manager) GetRequiredResources() ([]resource.KubernetesResource, error) {
-	if m.nexus == nil || m.client == nil {
-		return nil, fmt.Errorf(mgrNotInit)
-	}
-
 	var resources []resource.KubernetesResource
 	if m.nexus.Spec.Persistence.Persistent {
 		log.Debugf("Creating Persistent Volume Claim (%s)", m.nexus.Name)
@@ -77,10 +73,6 @@ func (m *Manager) GetRequiredResources() ([]resource.KubernetesResource, error) 
 
 // GetDeployedResources returns the persistence resources deployed on the cluster
 func (m *Manager) GetDeployedResources() ([]resource.KubernetesResource, error) {
-	if m.nexus == nil || m.client == nil {
-		return nil, fmt.Errorf(mgrNotInit)
-	}
-
 	var resources []resource.KubernetesResource
 	if pvc, err := m.getDeployedPVC(); err == nil {
 		resources = append(resources, pvc)

--- a/pkg/controller/nexus/resource/persistence/manager_test.go
+++ b/pkg/controller/nexus/resource/persistence/manager_test.go
@@ -72,22 +72,16 @@ func TestManager_setDefaults(t *testing.T) {
 }
 
 func TestManager_GetRequiredResources(t *testing.T) {
-	// first, let's test with mgr that has not been init
-	mgr := &Manager{}
-	resources, err := mgr.GetDeployedResources()
-	assert.Nil(t, resources)
-	assert.EqualError(t, err, mgrNotInit)
-
 	// correctness of the generated resources is tested elsewhere
 	// here we just want to check if they have been created and returned
-	mgr = &Manager{
+	mgr := &Manager{
 		nexus:  baseNexus.DeepCopy(),
 		client: test.NewFakeClientBuilder().Build(),
 	}
 
 	// first, let's test without persistence
 	mgr.nexus.Spec.Persistence.Persistent = false
-	resources, err = mgr.GetRequiredResources()
+	resources, err := mgr.GetRequiredResources()
 	assert.Nil(t, err)
 	// there should be no PVC without persistence
 	assert.Len(t, resources, 0)
@@ -103,24 +97,18 @@ func TestManager_GetRequiredResources(t *testing.T) {
 }
 
 func TestManager_GetDeployedResources(t *testing.T) {
-	// first, let's test with mgr that has not been init
-	mgr := &Manager{}
-	resources, err := mgr.GetDeployedResources()
-	assert.Nil(t, resources)
-	assert.EqualError(t, err, mgrNotInit)
-
-	// now a valid mgr, but no deployed resources
+	// first with no deployed resources
 	fakeClient := test.NewFakeClientBuilder().Build()
-	mgr = &Manager{
+	mgr := &Manager{
 		nexus:  baseNexus,
 		client: fakeClient,
 	}
-	resources, err = mgr.GetDeployedResources()
+	resources, err := mgr.GetDeployedResources()
 	assert.Nil(t, resources)
 	assert.Len(t, resources, 0)
 	assert.NoError(t, err)
 
-	// now a valid mgr with a deployed PVC
+	// now with a deployed PVC
 	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: mgr.nexus.Name, Namespace: mgr.nexus.Namespace}}
 	assert.NoError(t, mgr.client.Create(ctx.TODO(), pvc))
 

--- a/pkg/controller/nexus/resource/security/manager.go
+++ b/pkg/controller/nexus/resource/security/manager.go
@@ -30,11 +30,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const mgrNotInit = "the manager has not been initialized"
-
 var log = logger.GetLogger("security_manager")
 
 // Manager is responsible for creating security resources, fetching deployed ones and comparing them
+// Use with zero values will result in a panic. Use the NewManager function to get a properly initialized manager
 type Manager struct {
 	nexus  *v1alpha1.Nexus
 	client client.Client
@@ -59,10 +58,6 @@ func (m *Manager) setDefaults() {
 
 // GetRequiredResources returns the resources initialized by the Manager
 func (m *Manager) GetRequiredResources() ([]resource.KubernetesResource, error) {
-	if m.nexus == nil || m.client == nil {
-		return nil, fmt.Errorf(mgrNotInit)
-	}
-
 	log.Debugf("Creating Service Account (%s)", m.nexus.Name)
 	svcAccnt := defaultServiceAccount(m.nexus)
 	return []resource.KubernetesResource{svcAccnt}, nil
@@ -70,10 +65,6 @@ func (m *Manager) GetRequiredResources() ([]resource.KubernetesResource, error) 
 
 // GetDeployedResources returns the security resources deployed on the cluster
 func (m *Manager) GetDeployedResources() ([]resource.KubernetesResource, error) {
-	if m.nexus == nil || m.client == nil {
-		return nil, fmt.Errorf(mgrNotInit)
-	}
-
 	var resources []resource.KubernetesResource
 	if svcAccnt, err := m.getDeployedSvcAccnt(); err == nil {
 		resources = append(resources, svcAccnt)

--- a/pkg/controller/nexus/resource/security/manager_test.go
+++ b/pkg/controller/nexus/resource/security/manager_test.go
@@ -81,46 +81,34 @@ func TestManager_setDefaults(t *testing.T) {
 }
 
 func TestManager_GetRequiredResources(t *testing.T) {
-	// first, let's test with mgr that has not been init
-	mgr := &Manager{}
-	resources, err := mgr.GetDeployedResources()
-	assert.Nil(t, resources)
-	assert.EqualError(t, err, mgrNotInit)
-
 	// correctness of the generated resources is tested elsewhere
 	// here we just want to check if they have been created and returned
-	mgr = &Manager{
+	mgr := &Manager{
 		nexus:  baseNexus.DeepCopy(),
 		client: test.NewFakeClientBuilder().Build(),
 	}
 
 	// the default service accout is _always_ created
 	// even if the user specified a different one
-	resources, err = mgr.GetRequiredResources()
+	resources, err := mgr.GetRequiredResources()
 	assert.Nil(t, err)
 	assert.Len(t, resources, 1)
 	assert.True(t, test.ContainsType(resources, reflect.TypeOf(&corev1.ServiceAccount{})))
 }
 
 func TestManager_GetDeployedResources(t *testing.T) {
-	// first, let's test with mgr that has not been init
-	mgr := &Manager{}
-	resources, err := mgr.GetDeployedResources()
-	assert.Nil(t, resources)
-	assert.EqualError(t, err, mgrNotInit)
-
-	// now a valid mgr, but no deployed resources
+	// first with no deployed resources
 	fakeClient := test.NewFakeClientBuilder().Build()
-	mgr = &Manager{
+	mgr := &Manager{
 		nexus:  baseNexus,
 		client: fakeClient,
 	}
-	resources, err = mgr.GetDeployedResources()
+	resources, err := mgr.GetDeployedResources()
 	assert.Nil(t, resources)
 	assert.Len(t, resources, 0)
 	assert.NoError(t, err)
 
-	// now a valid mgr with a deployed Service Account
+	// now with a deployed Service Account
 	pvc := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: mgr.nexus.Name, Namespace: mgr.nexus.Namespace}}
 	assert.NoError(t, mgr.client.Create(ctx.TODO(), pvc))
 


### PR DESCRIPTION
We shouldn't return an error here just to avoid a panic for nil
dereference, we should embrace it as a clear way of letting the caller
know that this is a consequence of incorrect usage and it's most
definitely not an expected outcome from these methods.

Fix #116

Signed-off-by: Lucas Caparelli <lucas.caparelli112@gmail.com>