### PR TITLE
Change references to 'main' branch

### DIFF
--- a/.github/workflows/nexus-operator-integration-checks.yml
+++ b/.github/workflows/nexus-operator-integration-checks.yml
@@ -10,7 +10,7 @@ on:
       - "Makefile"
       - ".github/ISSUE_TEMPLATE/**"
     branches:
-      - master
+      - main
 env:
   OPERATOR_SDK_VERSION: v0.18.1
   GO_VERSION: 1.14

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ data:
 
 ### TLS/SSL
 
-For details about TLS configuration check out our [TLS guide](https://github.com/m88i/nexus-operator/tree/master/docs/TLS.md).
+For details about TLS configuration check out our [TLS guide](https://github.com/m88i/nexus-operator/tree/main/docs/TLS.md).
 
 ## Persistence
 

--- a/deploy/olm-catalog/nexus-operator/0.3.0/nexus-operator.v0.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nexus-operator/0.3.0/nexus-operator.v0.3.0.clusterserviceversion.yaml
@@ -137,7 +137,7 @@ spec:
     * Creates an [Ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress/) in Kubernetes (1.14+) environments to expose the application to the world
     * On OpenShift, creates a Route to expose the service outside the cluster
 
-    [See our documentation](https://github.com/m88i/nexus-operator/blob/master/README.md) for more installation and usage scenarios.
+    [See our documentation](https://github.com/m88i/nexus-operator/blob/main/README.md) for more installation and usage scenarios.
 
     If you experience any issues or have any ideas for new features, please [file an issue in our Github repository](https://github.com/m88i/nexus-operator/issues) or send an email to our maillist: [nexus-operator@googlegroups.com](mailto:nexus-operator@googlegroups.com)
 
@@ -309,7 +309,7 @@ spec:
     name: nexus-operator
   links:
   - name: Documentation
-    url: https://github.com/m88i/nexus-operator/blob/master/README.md
+    url: https://github.com/m88i/nexus-operator/blob/main/README.md
   - name: Nexus Operator source code repository
     url: https://github.com/m88i/nexus-operator
   maintainers:

--- a/deploy/olm-catalog/nexus-operator/manifests/nexus-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nexus-operator/manifests/nexus-operator.clusterserviceversion.yaml
@@ -137,7 +137,7 @@ spec:
     * Creates an [Ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress/) in Kubernetes (1.14+) environments to expose the application to the world
     * On OpenShift, creates a Route to expose the service outside the cluster
 
-    [See our documentation](https://github.com/m88i/nexus-operator/blob/master/README.md) for more installation and usage scenarios.
+    [See our documentation](https://github.com/m88i/nexus-operator/blob/main/README.md) for more installation and usage scenarios.
 
     If you experience any issues or have any ideas for new features, please [file an issue in our Github repository](https://github.com/m88i/nexus-operator/issues) or send an email to our maillist: [nexus-operator@googlegroups.com](mailto:nexus-operator@googlegroups.com)
 
@@ -309,7 +309,7 @@ spec:
     name: nexus-operator
   links:
   - name: Documentation
-    url: https://github.com/m88i/nexus-operator/blob/master/README.md
+    url: https://github.com/m88i/nexus-operator/blob/main/README.md
   - name: Nexus Operator source code repository
     url: https://github.com/m88i/nexus-operator
   maintainers:

--- a/hack/ci/operatorhubio-catalog.Dockerfile
+++ b/hack/ci/operatorhubio-catalog.Dockerfile
@@ -29,7 +29,7 @@
 
 
 
-# this Dockerfile is based on https://github.com/operator-framework/community-operators/blob/master/upstream.Dockerfile
+# this Dockerfile is based on https://github.com/operator-framework/community-operators/blob/main/upstream.Dockerfile
 # we just changed the third line to include only our manifest in this registry. 
 # since we don't have dependencies from others operators, we're good to go
 FROM quay.io/operator-framework/upstream-registry-builder:v1.5.6 as builder


### PR DESCRIPTION
**Note**: easy to miss, but this PR is to merge to 'main', not 'master'.

Change references of the 'master' branch to the 'main' branch in our files, except for previous versions CSVs. The branch itself has already been created, but it needs to be set as default when we're ready to migrate.

I wonder if we should keep the 'master' branch alive so that links of previous releases pointing to our README don't break. We could add a banner at the top of the master's README explaining it's only kept for historical reasons and link it to the main branch.

Alternatively we could update previous releases links as well, but we'd need to push them again to Operator Hub. This would allow us to delete master without any issues. This would still break any other links to our repo that specifically use the master branch, though these aren't maintained by us and there isn't much to be done if we chose to delete the master.