### PR TITLE
Fix #156, equalizing SecurityContext object

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,13 @@ If you're running on Kubernetes, edit the Nexus resource to add a [valid host fo
 
 ### Openshift
 
-If you're running the Operator on Openshift (3.11 or 4.x+) and you're not using [Red Hat certified images](#red-hat-certified-images) it's also necessary to configure a [Security Context Constraints](https://docs.openshift.com/container-platform/3.11/admin_guide/manage_scc.html) (SCC) resource.
+If you're running the Operator on Openshift (3.11 or 4.x+) and **you're not using Red Hat image with persistence enabled**, that's anything other than `spec.useRedHatImage: true` and `spec.persistence.persistent: true`,
+it's also necessary to configure a [Security Context Constraints](https://docs.openshift.com/container-platform/3.11/admin_guide/manage_scc.html) (SCC) resource.
 
-This is necessary because the Nexus image requires its container to be ran as UID 200. The use of the `restricted` default SCC in Openshift results in a failure when starting the pods, as seen in [Issue #41](https://github.com/m88i/nexus-operator/issues/41) and [Issue #51](https://github.com/m88i/nexus-operator/issues/51) (see this issue for more details on why can't the Operator handle this for you as things are now).
+This is necessary because the Nexus image requires its container to be ran as UID 200. 
+The use of the `restricted` default SCC in Openshift results in a failure when starting the pods, as seen in [Issue #41](https://github.com/m88i/nexus-operator/issues/41) and [Issue #51](https://github.com/m88i/nexus-operator/issues/51) (see this issue for more details on why can't the Operator handle this for you as things are now).
 
-Valid SCC resources can be found at the `examples/` directory. You must associate the SCC with the `ServiceAccount` in use and change the SCC's `metadata.name` field (search for "<Change Me!>" in the file).
+Valid SCC resources can be found at the `examples/` directory. You must associate the SCC with the `ServiceAccount` in use.
 
 For persistent configurations:
 
@@ -85,12 +87,13 @@ $ oc apply -f examples/scc-volatile.yaml
 Once the SCC has been created, run:
 
 ```
-$ oc adm policy add-scc-to-user <SCCName> -z <ServiceAccountName>
+$ oc adm policy add-scc-to-user allow-nexus-userid-200 -z <ServiceAccountName>
 ```
 
 This command will bind the SCC we just created with the `ServiceAccount` being used to create the Pods.
 
-If you're [using a custom ServiceAccount](#service-account), replace "`<ServiceAccountName>`" with the name of that account. If you're not using a custom `ServiceAccount`, the operator has created a default one which has the same name as your Nexus CR, replace "`<ServiceAccountName>`" with that.
+If you're [using a custom ServiceAccount](#service-account), replace "`<ServiceAccountName>`" with the name of that account. 
+If you're not using a custom `ServiceAccount`, the operator has created a default one which has the same name as your Nexus CR, replace "`<ServiceAccountName>`" with that.
 
 ### Clean up
 

--- a/examples/nexus3-redhat-no-volume.yaml
+++ b/examples/nexus3-redhat-no-volume.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps.m88i.io/v1alpha1
+kind: Nexus
+metadata:
+  name: nexus3
+spec:
+  # Number of Nexus pod replicas (can't be increased after creation)
+  replicas: 1
+  # Here you can specify the image version to fulfill your needs. Defaults to docker.io/sonatype/nexus3:latest if useRedHatImage is set to false
+  #image: "docker.io/sonatype/nexus3:latest"
+  # let's use the centOS image since we do not have access to Red Hat Catalog
+  useRedHatImage: true
+  # Set the resources requests and limits for Nexus pods. See: https://help.sonatype.com/repomanager3/system-requirements
+  resources:
+    limits:
+      cpu: "2"
+      memory: "2Gi"
+    requests:
+      cpu: "1"
+      memory: "2Gi"
+  # Data persistence details
+  persistence:
+    # Should we persist Nexus data? Volatile only!
+    persistent: false
+  networking:
+    # let the operator expose the Nexus server for you (the method will be the one that fits better for your cluster)
+    expose: true

--- a/examples/scc-persistent.yaml
+++ b/examples/scc-persistent.yaml
@@ -1,7 +1,7 @@
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: <Change Me!>
+  name: allow-nexus-userid-200
 fsGroup:
   ranges:
     - max: 200

--- a/examples/scc-volatile.yaml
+++ b/examples/scc-volatile.yaml
@@ -1,7 +1,7 @@
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: <Change Me!>
+  name: allow-nexus-userid-200
 fsGroup:
   ranges:
     - max: 200

--- a/pkg/controller/nexus/resource/deployment/manager.go
+++ b/pkg/controller/nexus/resource/deployment/manager.go
@@ -91,7 +91,7 @@ func deploymentEqual(deployed resource.KubernetesResource, requested resource.Ku
 	depDeployment := deployed.(*appsv1.Deployment)
 	reqDeployment := requested.(*appsv1.Deployment)
 
-	equalizeSecurityContext(depDeployment, reqDeployment)
+	normalizeSecurityContext(depDeployment, reqDeployment)
 
 	var pairs [][2]interface{}
 	pairs = append(pairs, [2]interface{}{depDeployment.Name, reqDeployment.Name})
@@ -132,7 +132,7 @@ func equalPullPolicies(depDeployment, reqDeployment *appsv1.Deployment) bool {
 // see: https://github.com/m88i/nexus-operator/issues/156
 // On OpenShift 4.5+ `SecurityContext` is not nil, but a "blank" object.
 // Since we are requesting a nil object in this context, we consider the deployed object to be nil as well.
-func equalizeSecurityContext(depDeployment, reqDeployment *appsv1.Deployment) {
+func normalizeSecurityContext(depDeployment, reqDeployment *appsv1.Deployment) {
 	if reqDeployment.Spec.Template.Spec.SecurityContext == nil {
 		depDeployment.Spec.Template.Spec.SecurityContext = nil
 	}


### PR DESCRIPTION
This PR fixes #156 

@LCaparelli also tested the new RBAC rules from #158 and it's working perfectly.

Testing this changes, I came up with another bug related to this one: [Red Hat images with volatile configurations also requires the SCC](https://github.com/sonatype/docker-nexus3/blob/master/Dockerfile.rh.el#L73). The only configuration we won't need the SCC configured, is Red Hat images with a PV associated. That's because OpenShift will configure the mounted PV to be accessible by the [UID created in the image](https://github.com/sonatype/docker-rhel-nexus/blob/master/uid_entrypoint). Also see: https://github.com/sonatype/docker-nexus3#red-hat-certified-image

Signed-off-by: Ricardo Zanini <zanini@redhat.com>