### PR TITLE
Implement identifiable logging

### DIFF
--- a/hack/go-fmt.sh
+++ b/hack/go-fmt.sh
@@ -17,7 +17,7 @@
 gofmt -s -l -w cmd/ pkg/ version/
 # get the goimports binary
 command -v goimports >/dev/null || go build -o $GOPATH/bin/goimports golang.org/x/tools/cmd/goimports
-goimports -l -w cmd/ pkg/ version/
+goimports -local github.com/m88i/nexus-operator -l -w cmd/ pkg/ version/
 
 if [[ -n ${CI} ]]; then
     git diff --exit-code

--- a/pkg/cluster/kubernetes/events_test.go
+++ b/pkg/cluster/kubernetes/events_test.go
@@ -19,12 +19,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/test"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/test"
 )
 
 func TestRaiseInfoEventf(t *testing.T) {

--- a/pkg/cluster/kubernetes/ingress.go
+++ b/pkg/cluster/kubernetes/ingress.go
@@ -18,12 +18,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/m88i/nexus-operator/pkg/util"
 	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/m88i/nexus-operator/pkg/util"
 )
 
 const ingressGroup = networking.GroupName

--- a/pkg/cluster/openshift/routes.go
+++ b/pkg/cluster/openshift/routes.go
@@ -18,12 +18,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/m88i/nexus-operator/pkg/util"
 	v1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/m88i/nexus-operator/pkg/util"
 )
 
 const (

--- a/pkg/controller/nexus/nexus_controller.go
+++ b/pkg/controller/nexus/nexus_controller.go
@@ -20,21 +20,9 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/m88i/nexus-operator/pkg/cluster/kubernetes"
-	"github.com/m88i/nexus-operator/pkg/cluster/openshift"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/validation"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/server"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/update"
-	"github.com/m88i/nexus-operator/pkg/framework"
-	"github.com/m88i/nexus-operator/pkg/logger"
-	routev1 "github.com/openshift/api/route/v1"
-
 	resUtils "github.com/RHsyseng/operator-utils/pkg/resource"
 	"github.com/RHsyseng/operator-utils/pkg/resource/write"
-
-	appsv1alpha1 "github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource"
-
+	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1beta1"
@@ -50,6 +38,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	appsv1alpha1 "github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/cluster/kubernetes"
+	"github.com/m88i/nexus-operator/pkg/cluster/openshift"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/validation"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/server"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/update"
+	"github.com/m88i/nexus-operator/pkg/framework"
+	"github.com/m88i/nexus-operator/pkg/logger"
 )
 
 var log = logger.GetLogger("controller_nexus")

--- a/pkg/controller/nexus/nexus_controller_test.go
+++ b/pkg/controller/nexus/nexus_controller_test.go
@@ -17,15 +17,10 @@ package nexus
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
-	"reflect"
-
 	resUtils "github.com/RHsyseng/operator-utils/pkg/resource"
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	nexusres "github.com/m88i/nexus-operator/pkg/controller/nexus/resource"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/validation"
-	"github.com/m88i/nexus-operator/pkg/test"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
@@ -37,6 +32,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	nexusres "github.com/m88i/nexus-operator/pkg/controller/nexus/resource"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/validation"
+	"github.com/m88i/nexus-operator/pkg/test"
 )
 
 func TestReconcileNexus_Reconcile_NoInstance(t *testing.T) {

--- a/pkg/controller/nexus/resource/deployment/deployment.go
+++ b/pkg/controller/nexus/resource/deployment/deployment.go
@@ -20,14 +20,14 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
-
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
 )
 
 const (

--- a/pkg/controller/nexus/resource/deployment/deployment_test.go
+++ b/pkg/controller/nexus/resource/deployment/deployment_test.go
@@ -18,14 +18,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/validation"
-
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/validation"
 )
 
 func Test_newDeployment_WithoutPersistence(t *testing.T) {

--- a/pkg/controller/nexus/resource/deployment/manager.go
+++ b/pkg/controller/nexus/resource/deployment/manager.go
@@ -119,6 +119,11 @@ func deploymentEqual(deployed resource.KubernetesResource, requested resource.Ku
 
 	equal := compare.EqualPairs(pairs)
 	equal = equal && equalPullPolicies(depDeployment, reqDeployment)
+
+	if !equal {
+		logger.GetLogger("deployment_manager").Info("Resources are not equal", "deployed", deployed, "requested", requested)
+	}
+
 	return equal
 }
 

--- a/pkg/controller/nexus/resource/deployment/manager.go
+++ b/pkg/controller/nexus/resource/deployment/manager.go
@@ -16,20 +16,20 @@ package deployment
 
 import (
 	"fmt"
-	"github.com/m88i/nexus-operator/pkg/logger"
-	"go.uber.org/zap"
 	"reflect"
-
 	"strings"
 
 	"github.com/RHsyseng/operator-utils/pkg/resource"
 	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/framework"
+	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/framework"
+	"github.com/m88i/nexus-operator/pkg/logger"
 )
 
 var managedObjectsRef = map[string]resource.KubernetesResource{

--- a/pkg/controller/nexus/resource/deployment/manager.go
+++ b/pkg/controller/nexus/resource/deployment/manager.go
@@ -16,6 +16,8 @@ package deployment
 
 import (
 	"fmt"
+	"github.com/m88i/nexus-operator/pkg/logger"
+	"go.uber.org/zap"
 	"reflect"
 
 	"strings"
@@ -31,8 +33,8 @@ import (
 )
 
 var managedObjectsRef = map[string]resource.KubernetesResource{
-	"Service":    &corev1.Service{},
-	"Deployment": &appsv1.Deployment{},
+	framework.DeploymentKind: &appsv1.Deployment{},
+	framework.ServiceKind:    &corev1.Service{},
 }
 
 // Manager is responsible for creating deployment-related resources, fetching deployed ones and comparing them
@@ -40,6 +42,7 @@ var managedObjectsRef = map[string]resource.KubernetesResource{
 type Manager struct {
 	nexus  *v1alpha1.Nexus
 	client client.Client
+	log    *zap.SugaredLogger
 }
 
 // NewManager creates a deployment resources manager
@@ -48,11 +51,14 @@ func NewManager(nexus *v1alpha1.Nexus, client client.Client) *Manager {
 	return &Manager{
 		nexus:  nexus,
 		client: client,
+		log:    logger.GetLoggerWithResource("deployment_manager", nexus),
 	}
 }
 
 // GetRequiredResources returns the resources initialized by the manager
 func (m *Manager) GetRequiredResources() ([]resource.KubernetesResource, error) {
+	m.log.Debugf("Generating required %s", framework.DeploymentKind)
+	m.log.Debugf("Generating required %s", framework.ServiceKind)
 	return []resource.KubernetesResource{newDeployment(m.nexus), newService(m.nexus)}, nil
 }
 
@@ -60,10 +66,10 @@ func (m *Manager) GetRequiredResources() ([]resource.KubernetesResource, error) 
 func (m *Manager) GetDeployedResources() ([]resource.KubernetesResource, error) {
 	var resources []resource.KubernetesResource
 	for resType, resRef := range managedObjectsRef {
-		if err := framework.Fetch(m.client, framework.Key(m.nexus), resRef); err == nil {
+		if err := framework.Fetch(m.client, framework.Key(m.nexus), resRef, resType); err == nil {
 			resources = append(resources, resRef)
 		} else if !errors.IsNotFound(err) {
-			return nil, fmt.Errorf("could not fetch Resource %s (%s): %v", resType, m.nexus.Name, err)
+			return nil, fmt.Errorf("could not fetch %s (%s/%s): %v", resType, m.nexus.Namespace, m.nexus.Name, err)
 		}
 	}
 	return resources, nil

--- a/pkg/controller/nexus/resource/deployment/manager_test.go
+++ b/pkg/controller/nexus/resource/deployment/manager_test.go
@@ -17,6 +17,7 @@ package deployment
 import (
 	ctx "context"
 	"fmt"
+	"github.com/m88i/nexus-operator/pkg/logger"
 	"reflect"
 	"testing"
 
@@ -54,9 +55,8 @@ func TestNewManager(t *testing.T) {
 		client: client,
 	}
 	got := NewManager(nexus, client)
-	if !reflect.DeepEqual(want, got) {
-		t.Errorf("TestNewManager()\nWant: %+v\tGot: %+v", want, got)
-	}
+	assert.Equal(t, want.nexus, got.nexus)
+	assert.Equal(t, want.client, got.client)
 }
 
 func TestManager_GetRequiredResources(t *testing.T) {
@@ -65,6 +65,7 @@ func TestManager_GetRequiredResources(t *testing.T) {
 	mgr := &Manager{
 		nexus:  allDefaultsCommunityNexus,
 		client: test.NewFakeClientBuilder().Build(),
+		log:    logger.GetLoggerWithResource("test", allDefaultsCommunityNexus),
 	}
 	resources, err := mgr.GetRequiredResources()
 	assert.Nil(t, err)

--- a/pkg/controller/nexus/resource/deployment/manager_test.go
+++ b/pkg/controller/nexus/resource/deployment/manager_test.go
@@ -17,18 +17,19 @@ package deployment
 import (
 	ctx "context"
 	"fmt"
-	"github.com/m88i/nexus-operator/pkg/logger"
 	"reflect"
 	"testing"
 
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/validation"
-	"github.com/m88i/nexus-operator/pkg/test"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/validation"
+	"github.com/m88i/nexus-operator/pkg/logger"
+	"github.com/m88i/nexus-operator/pkg/test"
 )
 
 var (

--- a/pkg/controller/nexus/resource/deployment/service.go
+++ b/pkg/controller/nexus/resource/deployment/service.go
@@ -15,10 +15,11 @@
 package deployment
 
 import (
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
 )
 
 const (

--- a/pkg/controller/nexus/resource/deployment/service_test.go
+++ b/pkg/controller/nexus/resource/deployment/service_test.go
@@ -17,10 +17,11 @@ package deployment
 import (
 	"testing"
 
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
 )
 
 func Test_newService(t *testing.T) {

--- a/pkg/controller/nexus/resource/interfaces.go
+++ b/pkg/controller/nexus/resource/interfaces.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/RHsyseng/operator-utils/pkg/resource"
 	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
+
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 )
 

--- a/pkg/controller/nexus/resource/meta/object.go
+++ b/pkg/controller/nexus/resource/meta/object.go
@@ -15,8 +15,9 @@
 package meta
 
 import (
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 )
 
 const AppLabel = "app"

--- a/pkg/controller/nexus/resource/networking/ingress.go
+++ b/pkg/controller/nexus/resource/networking/ingress.go
@@ -15,11 +15,12 @@
 package networking
 
 import (
+	"k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
-	"k8s.io/api/networking/v1beta1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (

--- a/pkg/controller/nexus/resource/networking/ingress_test.go
+++ b/pkg/controller/nexus/resource/networking/ingress_test.go
@@ -17,13 +17,14 @@ package networking
 import (
 	"testing"
 
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
 )
 
 var (

--- a/pkg/controller/nexus/resource/networking/manager.go
+++ b/pkg/controller/nexus/resource/networking/manager.go
@@ -178,5 +178,9 @@ func ingressEqual(deployed resource.KubernetesResource, requested resource.Kuber
 	pairs = append(pairs, [2]interface{}{ingress1.Namespace, ingress2.Namespace})
 	pairs = append(pairs, [2]interface{}{ingress1.Spec, ingress2.Spec})
 
-	return compare.EqualPairs(pairs)
+	equal := compare.EqualPairs(pairs)
+	if !equal {
+		logger.GetLogger("networking_manager").Info("Resources are not equal", "deployed", deployed, "requested", requested)
+	}
+	return equal
 }

--- a/pkg/controller/nexus/resource/networking/manager.go
+++ b/pkg/controller/nexus/resource/networking/manager.go
@@ -16,21 +16,22 @@ package networking
 
 import (
 	"fmt"
-	"github.com/m88i/nexus-operator/pkg/framework"
-	"go.uber.org/zap"
 	"reflect"
 
 	"github.com/RHsyseng/operator-utils/pkg/resource"
 	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/cluster/kubernetes"
-	"github.com/m88i/nexus-operator/pkg/cluster/openshift"
-	"github.com/m88i/nexus-operator/pkg/logger"
 	routev1 "github.com/openshift/api/route/v1"
+	"go.uber.org/zap"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/cluster/kubernetes"
+	"github.com/m88i/nexus-operator/pkg/cluster/openshift"
+	"github.com/m88i/nexus-operator/pkg/framework"
+	"github.com/m88i/nexus-operator/pkg/logger"
 )
 
 const (

--- a/pkg/controller/nexus/resource/networking/manager_test.go
+++ b/pkg/controller/nexus/resource/networking/manager_test.go
@@ -17,19 +17,20 @@ package networking
 import (
 	ctx "context"
 	"fmt"
-	"github.com/m88i/nexus-operator/pkg/logger"
 	"reflect"
 	"testing"
 
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
-	"github.com/m88i/nexus-operator/pkg/test"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
+	"github.com/m88i/nexus-operator/pkg/logger"
+	"github.com/m88i/nexus-operator/pkg/test"
 )
 
 var nodePortNexus = &v1alpha1.Nexus{

--- a/pkg/controller/nexus/resource/networking/manager_test.go
+++ b/pkg/controller/nexus/resource/networking/manager_test.go
@@ -17,6 +17,7 @@ package networking
 import (
 	ctx "context"
 	"fmt"
+	"github.com/m88i/nexus-operator/pkg/logger"
 	"reflect"
 	"testing"
 
@@ -124,9 +125,11 @@ func TestManager_GetRequiredResources(t *testing.T) {
 	// correctness of the generated resources is tested elsewhere
 	// here we just want to check if they have been created and returned
 	// first, let's test a Nexus which does not expose
+	nexus := &v1alpha1.Nexus{Spec: v1alpha1.NexusSpec{Networking: v1alpha1.NexusNetworking{Expose: false}}}
 	mgr := &Manager{
-		nexus:  &v1alpha1.Nexus{Spec: v1alpha1.NexusSpec{Networking: v1alpha1.NexusNetworking{Expose: false}}},
+		nexus:  nexus,
 		client: test.NewFakeClientBuilder().Build(),
+		log:    logger.GetLoggerWithResource("test", nexus),
 	}
 	resources, err := mgr.GetRequiredResources()
 	assert.Nil(t, resources)
@@ -136,6 +139,7 @@ func TestManager_GetRequiredResources(t *testing.T) {
 	mgr = &Manager{
 		nexus:          routeNexus,
 		client:         test.NewFakeClientBuilder().OnOpenshift().Build(),
+		log:            logger.GetLoggerWithResource("test", routeNexus),
 		routeAvailable: true,
 		ocp:            true,
 	}
@@ -147,6 +151,7 @@ func TestManager_GetRequiredResources(t *testing.T) {
 	// still a route, but in a cluster without routes
 	mgr = &Manager{
 		nexus:  routeNexus,
+		log:    logger.GetLoggerWithResource("test", routeNexus),
 		client: test.NewFakeClientBuilder().Build(),
 	}
 	resources, err = mgr.GetRequiredResources()
@@ -157,6 +162,7 @@ func TestManager_GetRequiredResources(t *testing.T) {
 	mgr = &Manager{
 		nexus:            ingressNexus,
 		client:           test.NewFakeClientBuilder().WithIngress().Build(),
+		log:              logger.GetLoggerWithResource("test", ingressNexus),
 		ingressAvailable: true,
 	}
 	resources, err = mgr.GetRequiredResources()
@@ -167,6 +173,7 @@ func TestManager_GetRequiredResources(t *testing.T) {
 	// still an ingress, but in a cluster without ingresses
 	mgr = &Manager{
 		nexus:  ingressNexus,
+		log:    logger.GetLoggerWithResource("test", ingressNexus),
 		client: test.NewFakeClientBuilder().Build(),
 	}
 	resources, err = mgr.GetRequiredResources()
@@ -234,44 +241,6 @@ func TestManager_GetDeployedResources(t *testing.T) {
 	resources, err = mgr.GetDeployedResources()
 	assert.Nil(t, resources)
 	assert.Contains(t, err.Error(), mockErrorMsg)
-}
-
-func TestManager_getDeployedRoute(t *testing.T) {
-	mgr := &Manager{
-		nexus:  routeNexus,
-		client: test.NewFakeClientBuilder().OnOpenshift().Build(),
-	}
-
-	// first, test without creating the route
-	route, err := mgr.getDeployedRoute()
-	assert.Nil(t, route)
-	assert.True(t, errors.IsNotFound(err))
-
-	// now test after creating the route
-	route = &routev1.Route{ObjectMeta: metav1.ObjectMeta{Name: mgr.nexus.Name, Namespace: mgr.nexus.Namespace}}
-	assert.NoError(t, mgr.client.Create(ctx.TODO(), route))
-	route, err = mgr.getDeployedRoute()
-	assert.NotNil(t, route)
-	assert.NoError(t, err)
-}
-
-func TestManager_getDeployedIngress(t *testing.T) {
-	mgr := &Manager{
-		nexus:  ingressNexus,
-		client: test.NewFakeClientBuilder().WithIngress().Build(),
-	}
-
-	// first, test without creating the ingress
-	ingress, err := mgr.getDeployedIngress()
-	assert.Nil(t, ingress)
-	assert.True(t, errors.IsNotFound(err))
-
-	// now test after creating the ingress
-	ingress = &networkingv1beta1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: mgr.nexus.Name, Namespace: mgr.nexus.Namespace}}
-	assert.NoError(t, mgr.client.Create(ctx.TODO(), ingress))
-	ingress, err = mgr.getDeployedIngress()
-	assert.NotNil(t, ingress)
-	assert.NoError(t, err)
 }
 
 func TestManager_GetCustomComparator(t *testing.T) {

--- a/pkg/controller/nexus/resource/networking/route.go
+++ b/pkg/controller/nexus/resource/networking/route.go
@@ -15,12 +15,13 @@
 package networking
 
 import (
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
 	v1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
 )
 
 var serviceKind = (&corev1.Service{}).GroupVersionKind().Kind

--- a/pkg/controller/nexus/resource/networking/route_test.go
+++ b/pkg/controller/nexus/resource/networking/route_test.go
@@ -17,14 +17,15 @@ package networking
 import (
 	"testing"
 
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
 	v1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
 )
 
 var (

--- a/pkg/controller/nexus/resource/persistence/manager.go
+++ b/pkg/controller/nexus/resource/persistence/manager.go
@@ -16,16 +16,17 @@ package persistence
 
 import (
 	"fmt"
-	"github.com/m88i/nexus-operator/pkg/framework"
-	"go.uber.org/zap"
 	"reflect"
 
 	"github.com/RHsyseng/operator-utils/pkg/resource"
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/logger"
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/framework"
+	"github.com/m88i/nexus-operator/pkg/logger"
 )
 
 var managedObjectsRef = map[string]resource.KubernetesResource{

--- a/pkg/controller/nexus/resource/persistence/manager.go
+++ b/pkg/controller/nexus/resource/persistence/manager.go
@@ -15,8 +15,9 @@
 package persistence
 
 import (
-	ctx "context"
 	"fmt"
+	"github.com/m88i/nexus-operator/pkg/framework"
+	"go.uber.org/zap"
 	"reflect"
 
 	"github.com/RHsyseng/operator-utils/pkg/resource"
@@ -24,17 +25,19 @@ import (
 	"github.com/m88i/nexus-operator/pkg/logger"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var log = logger.GetLogger("persistence_manager")
+var managedObjectsRef = map[string]resource.KubernetesResource{
+	framework.PVCKind: &corev1.PersistentVolumeClaim{},
+}
 
 // Manager is responsible for creating persistence resources, fetching deployed ones and comparing them
 // Use with zero values will result in a panic. Use the NewManager function to get a properly initialized manager
 type Manager struct {
 	nexus  *v1alpha1.Nexus
 	client client.Client
+	log    *zap.SugaredLogger
 }
 
 // NewManager creates a persistence resources manager
@@ -43,44 +46,35 @@ func NewManager(nexus *v1alpha1.Nexus, client client.Client) *Manager {
 	return &Manager{
 		nexus:  nexus,
 		client: client,
+		log:    logger.GetLoggerWithResource("persistence_manager", nexus),
 	}
 }
 
 // GetRequiredResources returns the resources initialized by the manager
 func (m *Manager) GetRequiredResources() ([]resource.KubernetesResource, error) {
 	var resources []resource.KubernetesResource
-	if m.nexus.Spec.Persistence.Persistent {
-		log.Debugf("Creating Persistent Volume Claim (%s)", m.nexus.Name)
-		pvc := newPVC(m.nexus)
-		resources = append(resources, pvc)
+	if !m.nexus.Spec.Persistence.Persistent {
+		return resources, nil
 	}
+
+	m.log.Debugf("Generating required %s", framework.PVCKind)
+	pvc := newPVC(m.nexus)
+	resources = append(resources, pvc)
+
 	return resources, nil
 }
 
 // GetDeployedResources returns the persistence resources deployed on the cluster
 func (m *Manager) GetDeployedResources() ([]resource.KubernetesResource, error) {
 	var resources []resource.KubernetesResource
-	if pvc, err := m.getDeployedPVC(); err == nil {
-		resources = append(resources, pvc)
-	} else if !errors.IsNotFound(err) {
-		log.Errorf("Could not fetch Persistent Volume Claim (%s): %v", m.nexus.Name, err)
-		return nil, fmt.Errorf("could not fetch pvc (%s): %v", m.nexus.Name, err)
+	for resType, resRef := range managedObjectsRef {
+		if err := framework.Fetch(m.client, framework.Key(m.nexus), resRef, resType); err == nil {
+			resources = append(resources, resRef)
+		} else if !errors.IsNotFound(err) {
+			return nil, fmt.Errorf("could not fetch %s (%s/%s): %v", resType, m.nexus.Namespace, m.nexus.Name, err)
+		}
 	}
 	return resources, nil
-}
-
-func (m *Manager) getDeployedPVC() (resource.KubernetesResource, error) {
-	pvc := &corev1.PersistentVolumeClaim{}
-	key := types.NamespacedName{Namespace: m.nexus.Namespace, Name: m.nexus.Name}
-	log.Debugf("Attempting to fetch deployed Persistent Volume Claim (%s)", m.nexus.Name)
-	err := m.client.Get(ctx.TODO(), key, pvc)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			log.Debugf("There is no deployed Persistent Volume Claim (%s)", m.nexus.Name)
-		}
-		return nil, err
-	}
-	return pvc, nil
 }
 
 // GetCustomComparator returns the custom comp function used to compare a persistence resource.

--- a/pkg/controller/nexus/resource/persistence/manager_test.go
+++ b/pkg/controller/nexus/resource/persistence/manager_test.go
@@ -17,16 +17,17 @@ package persistence
 import (
 	ctx "context"
 	"fmt"
-	"github.com/m88i/nexus-operator/pkg/logger"
 	"reflect"
 	"testing"
 
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/test"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/logger"
+	"github.com/m88i/nexus-operator/pkg/test"
 )
 
 var baseNexus = &v1alpha1.Nexus{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "nexus"}}

--- a/pkg/controller/nexus/resource/persistence/pvc.go
+++ b/pkg/controller/nexus/resource/persistence/pvc.go
@@ -15,10 +15,11 @@
 package persistence
 
 import (
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
 )
 
 func newPVC(nexus *v1alpha1.Nexus) *corev1.PersistentVolumeClaim {

--- a/pkg/controller/nexus/resource/persistence/pvc_test.go
+++ b/pkg/controller/nexus/resource/persistence/pvc_test.go
@@ -17,12 +17,13 @@ package persistence
 import (
 	"testing"
 
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/validation"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/validation"
 )
 
 func Test_newPVC_defaultValues(t *testing.T) {

--- a/pkg/controller/nexus/resource/resources.go
+++ b/pkg/controller/nexus/resource/resources.go
@@ -16,23 +16,20 @@ package resource
 
 import (
 	"fmt"
-	"github.com/m88i/nexus-operator/pkg/logger"
-	"go.uber.org/zap"
 	"reflect"
 
+	"github.com/RHsyseng/operator-utils/pkg/resource"
 	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
+	"go.uber.org/zap"
+	"k8s.io/client-go/discovery"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/deployment"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/networking"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/persistence"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/security"
-
-	"k8s.io/client-go/discovery"
-
-	"github.com/RHsyseng/operator-utils/pkg/resource"
-
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/m88i/nexus-operator/pkg/logger"
 )
 
 const mgrsNotInit = "resource managers have not been initialized"

--- a/pkg/controller/nexus/resource/security/manager.go
+++ b/pkg/controller/nexus/resource/security/manager.go
@@ -16,16 +16,17 @@ package security
 
 import (
 	"fmt"
-	"github.com/m88i/nexus-operator/pkg/logger"
-	"go.uber.org/zap"
 	"reflect"
 
 	"github.com/RHsyseng/operator-utils/pkg/resource"
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/framework"
+	"go.uber.org/zap"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/framework"
+	"github.com/m88i/nexus-operator/pkg/logger"
 )
 
 var managedObjectsRef = map[string]resource.KubernetesResource{

--- a/pkg/controller/nexus/resource/security/manager_test.go
+++ b/pkg/controller/nexus/resource/security/manager_test.go
@@ -17,17 +17,19 @@ package security
 import (
 	ctx "context"
 	"fmt"
-	"github.com/m88i/nexus-operator/pkg/logger"
 	"reflect"
 	"testing"
 
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/framework"
-	"github.com/m88i/nexus-operator/pkg/test"
+	"github.com/m88i/nexus-operator/pkg/logger"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/framework"
+	"github.com/m88i/nexus-operator/pkg/test"
 )
 
 var baseNexus = &v1alpha1.Nexus{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "nexus"}, Spec: v1alpha1.NexusSpec{ServiceAccountName: "nexus"}}

--- a/pkg/controller/nexus/resource/security/secret.go
+++ b/pkg/controller/nexus/resource/security/secret.go
@@ -15,10 +15,10 @@
 package security
 
 import (
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 // defaultSecret all purposes secret used by this instance

--- a/pkg/controller/nexus/resource/security/service_account.go
+++ b/pkg/controller/nexus/resource/security/service_account.go
@@ -15,9 +15,10 @@
 package security
 
 import (
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
-	corev1 "k8s.io/api/core/v1"
 )
 
 func defaultServiceAccount(nexus *v1alpha1.Nexus) *corev1.ServiceAccount {

--- a/pkg/controller/nexus/resource/validation/defaults.go
+++ b/pkg/controller/nexus/resource/validation/defaults.go
@@ -15,10 +15,11 @@
 package validation
 
 import (
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	k8sres "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 )
 
 const (

--- a/pkg/controller/nexus/resource/validation/events.go
+++ b/pkg/controller/nexus/resource/validation/events.go
@@ -15,11 +15,12 @@
 package validation
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	"github.com/m88i/nexus-operator/pkg/cluster/kubernetes"
 	"github.com/m88i/nexus-operator/pkg/logger"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const changedNexusReason = "NexusSpecChanged"

--- a/pkg/controller/nexus/resource/validation/events.go
+++ b/pkg/controller/nexus/resource/validation/events.go
@@ -17,6 +17,7 @@ package validation
 import (
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	"github.com/m88i/nexus-operator/pkg/cluster/kubernetes"
+	"github.com/m88i/nexus-operator/pkg/logger"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -24,8 +25,9 @@ import (
 const changedNexusReason = "NexusSpecChanged"
 
 func createChangedNexusEvent(nexus *v1alpha1.Nexus, scheme *runtime.Scheme, c client.Client, field string) {
-	err := kubernetes.RaiseWarnEventf(nexus, scheme, c, changedNexusReason, "'%s' has been changed in %s. Check the logs for more information", field, nexus.Name)
+	log := logger.GetLoggerWithResource("validation_event", nexus)
+	err := kubernetes.RaiseWarnEventf(nexus, scheme, c, changedNexusReason, "'%s' has been changed in %s/%s. Check the logs for more information", field, nexus.Namespace, nexus.Name)
 	if err != nil {
-		log.Warnf("Unable to raise event for changing '%s' in Nexus (%s): %v", field, nexus.Name, err)
+		log.Warnf("Unable to raise event for changing '%s' in Nexus CR: %v", field, err)
 	}
 }

--- a/pkg/controller/nexus/resource/validation/events_test.go
+++ b/pkg/controller/nexus/resource/validation/events_test.go
@@ -19,11 +19,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/test"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/test"
 )
 
 func Test_createChangedNexusEvent(t *testing.T) {

--- a/pkg/controller/nexus/resource/validation/validation.go
+++ b/pkg/controller/nexus/resource/validation/validation.go
@@ -19,19 +19,16 @@ import (
 	"strings"
 
 	"go.uber.org/zap"
-
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
 
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	"github.com/m88i/nexus-operator/pkg/cluster/kubernetes"
 	"github.com/m88i/nexus-operator/pkg/cluster/openshift"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/update"
 	"github.com/m88i/nexus-operator/pkg/logger"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/discovery"
 )
 
 const (

--- a/pkg/controller/nexus/resource/validation/validation.go
+++ b/pkg/controller/nexus/resource/validation/validation.go
@@ -16,17 +16,20 @@ package validation
 
 import (
 	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"strings"
 
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	"github.com/m88i/nexus-operator/pkg/cluster/kubernetes"
 	"github.com/m88i/nexus-operator/pkg/cluster/openshift"
 	"github.com/m88i/nexus-operator/pkg/controller/nexus/update"
 	"github.com/m88i/nexus-operator/pkg/logger"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/discovery"
 )
@@ -37,11 +40,10 @@ const (
 	unspecifiedExposeAsFormat = "'spec.exposeAs' left unspecified, setting it to %s"
 )
 
-var log = logger.GetLogger("Nexus_validation")
-
 type Validator struct {
 	client client.Client
 	scheme *runtime.Scheme
+	log    *zap.SugaredLogger
 
 	routeAvailable, ingressAvailable, ocp bool
 }
@@ -74,6 +76,7 @@ func NewValidator(client client.Client, scheme *runtime.Scheme, disc discovery.D
 
 // SetDefaultsAndValidate returns a copy of the parameter Nexus with defaults set and an error if validation fails.
 func (v *Validator) SetDefaultsAndValidate(nexus *v1alpha1.Nexus) (*v1alpha1.Nexus, error) {
+	v.log = logger.GetLoggerWithResource("nexus_validation", nexus)
 	n := v.setDefaults(nexus)
 	return n, v.validate(n)
 }
@@ -84,37 +87,37 @@ func (v *Validator) validate(nexus *v1alpha1.Nexus) error {
 
 func (v *Validator) validateNetworking(nexus *v1alpha1.Nexus) error {
 	if !nexus.Spec.Networking.Expose {
-		log.Debugf("'spec.networking.expose' set to 'false', ignoring networking configuration")
+		v.log.Debugf("'spec.networking.expose' set to 'false', ignoring networking configuration")
 		return nil
 	}
 
 	if !v.ingressAvailable && nexus.Spec.Networking.ExposeAs == v1alpha1.IngressExposeType {
-		log.Errorf("Ingresses are not available on your cluster. Make sure to be running Kubernetes > 1.14 or if you're running Openshift set 'spec.networking.exposeAs' to '%s'. Alternatively you may also try '%s'", v1alpha1.IngressExposeType, v1alpha1.NodePortExposeType)
+		v.log.Errorf("Ingresses are not available on your cluster. Make sure to be running Kubernetes > 1.14 or if you're running Openshift set 'spec.networking.exposeAs' to '%s'. Alternatively you may also try '%s'", v1alpha1.IngressExposeType, v1alpha1.NodePortExposeType)
 		return fmt.Errorf("ingress expose required, but unavailable")
 	}
 
 	if !v.routeAvailable && nexus.Spec.Networking.ExposeAs == v1alpha1.RouteExposeType {
-		log.Errorf("Routes are not available on your cluster. If you're running Kubernetes 1.14 or higher try setting 'spec.networking.exposeAs' to '%s'. Alternatively you may also try '%s'", v1alpha1.IngressExposeType, v1alpha1.NodePortExposeType)
+		v.log.Errorf("Routes are not available on your cluster. If you're running Kubernetes 1.14 or higher try setting 'spec.networking.exposeAs' to '%s'. Alternatively you may also try '%s'", v1alpha1.IngressExposeType, v1alpha1.NodePortExposeType)
 		return fmt.Errorf("route expose required, but unavailable")
 	}
 
 	if nexus.Spec.Networking.ExposeAs == v1alpha1.NodePortExposeType && nexus.Spec.Networking.NodePort == 0 {
-		log.Errorf("NodePort networking requires a port. Check the Nexus resource 'spec.networking.nodePort' parameter")
+		v.log.Errorf("NodePort networking requires a port. Check the Nexus resource 'spec.networking.nodePort' parameter")
 		return fmt.Errorf("nodeport expose required, but no port informed")
 	}
 
 	if nexus.Spec.Networking.ExposeAs == v1alpha1.IngressExposeType && len(nexus.Spec.Networking.Host) == 0 {
-		log.Errorf("Ingress networking requires a host. Check the Nexus resource 'spec.networking.host' parameter")
+		v.log.Errorf("Ingress networking requires a host. Check the Nexus resource 'spec.networking.host' parameter")
 		return fmt.Errorf("ingress expose required, but no host informed")
 	}
 
 	if len(nexus.Spec.Networking.TLS.SecretName) > 0 && nexus.Spec.Networking.ExposeAs != v1alpha1.IngressExposeType {
-		log.Errorf("'spec.networking.tls.secretName' is only available when using an Ingress. Try setting 'spec.networking.exposeAs' to '%s'", v1alpha1.IngressExposeType)
+		v.log.Errorf("'spec.networking.tls.secretName' is only available when using an Ingress. Try setting 'spec.networking.exposeAs' to '%s'", v1alpha1.IngressExposeType)
 		return fmt.Errorf("tls secret name informed, but using route")
 	}
 
 	if nexus.Spec.Networking.TLS.Mandatory && nexus.Spec.Networking.ExposeAs != v1alpha1.RouteExposeType {
-		log.Errorf("'spec.networking.tls.mandatory' is only available when using a Route. Try setting 'spec.networking.exposeAs' to '%s'", v1alpha1.RouteExposeType)
+		v.log.Errorf("'spec.networking.tls.mandatory' is only available when using a Route. Try setting 'spec.networking.exposeAs' to '%s'", v1alpha1.RouteExposeType)
 		return fmt.Errorf("tls set to mandatory, but using ingress")
 	}
 
@@ -146,7 +149,7 @@ func (v *Validator) setResourcesDefaults(nexus *v1alpha1.Nexus) {
 func (v *Validator) setImageDefaults(nexus *v1alpha1.Nexus) {
 	if nexus.Spec.UseRedHatImage {
 		if len(nexus.Spec.Image) > 0 {
-			log.Warnf("Nexus CR configured to the use Red Hat Certified Image, ignoring 'spec.image' field.")
+			v.log.Warnf("Nexus CR configured to the use Red Hat Certified Image, ignoring 'spec.image' field.")
 		}
 		nexus.Spec.Image = NexusCertifiedImage
 	} else if len(nexus.Spec.Image) == 0 {
@@ -158,7 +161,7 @@ func (v *Validator) setImageDefaults(nexus *v1alpha1.Nexus) {
 		nexus.Spec.ImagePullPolicy != corev1.PullIfNotPresent &&
 		nexus.Spec.ImagePullPolicy != corev1.PullNever {
 
-		log.Warnf("Invalid 'spec.imagePullPolicy', unsetting the value. The pull policy will be determined by the image tag. Consider setting this value to '%s', '%s' or '%s'", corev1.PullAlways, corev1.PullIfNotPresent, corev1.PullNever)
+		v.log.Warnf("Invalid 'spec.imagePullPolicy', unsetting the value. The pull policy will be determined by the image tag. Consider setting this value to '%s', '%s' or '%s'", corev1.PullAlways, corev1.PullIfNotPresent, corev1.PullNever)
 		nexus.Spec.ImagePullPolicy = ""
 	}
 }
@@ -204,16 +207,16 @@ func (v *Validator) setUpdateDefaults(nexus *v1alpha1.Nexus) {
 
 	image := strings.Split(nexus.Spec.Image, ":")[0]
 	if image != NexusCommunityImage {
-		log.Warnf("Automatic Updates are enabled, but 'spec.image' is not using the community image (%s). Disabling automatic updates", NexusCommunityImage)
+		v.log.Warnf("Automatic Updates are enabled, but 'spec.image' is not using the community image (%s). Disabling automatic updates", NexusCommunityImage)
 		nexus.Spec.AutomaticUpdate.Disabled = true
 		return
 	}
 
 	if nexus.Spec.AutomaticUpdate.MinorVersion == nil {
-		log.Debugf("Automatic Updates are enabled, but no minor was informed. Fetching the most recent...")
+		v.log.Debugf("Automatic Updates are enabled, but no minor was informed. Fetching the most recent...")
 		minor, err := update.GetLatestMinor()
 		if err != nil {
-			log.Errorf("Unable to fetch the most recent minor: %v. Disabling automatic updates.", err)
+			v.log.Errorf("Unable to fetch the most recent minor: %v. Disabling automatic updates.", err)
 			nexus.Spec.AutomaticUpdate.Disabled = true
 			createChangedNexusEvent(nexus, v.scheme, v.client, "spec.automaticUpdate.disabled")
 			return
@@ -221,26 +224,26 @@ func (v *Validator) setUpdateDefaults(nexus *v1alpha1.Nexus) {
 		nexus.Spec.AutomaticUpdate.MinorVersion = &minor
 	}
 
-	log.Debugf("Fetching the latest micro from minor %d", *nexus.Spec.AutomaticUpdate.MinorVersion)
+	v.log.Debugf("Fetching the latest micro from minor %d", *nexus.Spec.AutomaticUpdate.MinorVersion)
 	tag, ok := update.GetLatestMicro(*nexus.Spec.AutomaticUpdate.MinorVersion)
 	if !ok {
 		// the informed minor doesn't exist, let's try the latest minor
-		log.Warnf("Latest tag for minor version (%d) not found. Trying the latest minor instead", *nexus.Spec.AutomaticUpdate.MinorVersion)
+		v.log.Warnf("Latest tag for minor version (%d) not found. Trying the latest minor instead", *nexus.Spec.AutomaticUpdate.MinorVersion)
 		minor, err := update.GetLatestMinor()
 		if err != nil {
-			log.Errorf("Unable to fetch the most recent minor: %v. Disabling automatic updates.", err)
+			v.log.Errorf("Unable to fetch the most recent minor: %v. Disabling automatic updates.", err)
 			nexus.Spec.AutomaticUpdate.Disabled = true
 			createChangedNexusEvent(nexus, v.scheme, v.client, "spec.automaticUpdate.disabled")
 			return
 		}
-		log.Infof("Setting 'spec.automaticUpdate.minorVersion to %d", minor)
+		v.log.Infof("Setting 'spec.automaticUpdate.minorVersion to %d", minor)
 		nexus.Spec.AutomaticUpdate.MinorVersion = &minor
 		// no need to check for the tag existence here,
 		// we would have gotten an error from GetLatestMinor() if it didn't
 		tag, _ = update.GetLatestMicro(minor)
 	}
 	newImage := fmt.Sprintf("%s:%s", image, tag)
-	log.Debugf("Replacing 'spec.image' (%s) with '%s'", nexus.Spec.Image, newImage)
+	v.log.Debugf("Replacing 'spec.image' (%s) with '%s'", nexus.Spec.Image, newImage)
 	nexus.Spec.Image = newImage
 }
 
@@ -251,16 +254,16 @@ func (v *Validator) setNetworkingDefaults(nexus *v1alpha1.Nexus) {
 
 	if len(nexus.Spec.Networking.ExposeAs) == 0 {
 		if v.ocp {
-			log.Infof(unspecifiedExposeAsFormat, v1alpha1.RouteExposeType)
+			v.log.Infof(unspecifiedExposeAsFormat, v1alpha1.RouteExposeType)
 			nexus.Spec.Networking.ExposeAs = v1alpha1.RouteExposeType
 		} else if v.ingressAvailable {
-			log.Infof(unspecifiedExposeAsFormat, v1alpha1.IngressExposeType)
+			v.log.Infof(unspecifiedExposeAsFormat, v1alpha1.IngressExposeType)
 			nexus.Spec.Networking.ExposeAs = v1alpha1.IngressExposeType
 		} else {
 			// we're on kubernetes < 1.14
 			// try setting nodePort, validation will catch it if impossible
-			log.Info("On Kubernetes, but Ingresses are not available")
-			log.Infof(unspecifiedExposeAsFormat, v1alpha1.NodePortExposeType)
+			v.log.Info("On Kubernetes, but Ingresses are not available")
+			v.log.Infof(unspecifiedExposeAsFormat, v1alpha1.NodePortExposeType)
 			nexus.Spec.Networking.ExposeAs = v1alpha1.NodePortExposeType
 		}
 	}

--- a/pkg/controller/nexus/resource/validation/validation_test.go
+++ b/pkg/controller/nexus/resource/validation/validation_test.go
@@ -16,6 +16,7 @@ package validation
 
 import (
 	"fmt"
+	"github.com/m88i/nexus-operator/pkg/logger"
 	"reflect"
 	"testing"
 
@@ -189,9 +190,10 @@ func TestValidator_SetDefaultsAndValidate_Deployment(t *testing.T) {
 
 func TestValidator_setUpdateDefaults(t *testing.T) {
 	client := test.NewFakeClientBuilder().Build()
-	v, _ := NewValidator(client, client.Scheme(), client)
 	nexus := &v1alpha1.Nexus{Spec: v1alpha1.NexusSpec{AutomaticUpdate: v1alpha1.NexusAutomaticUpdate{}}}
 	nexus.Spec.Image = NexusCommunityImage
+	v, _ := NewValidator(client, client.Scheme(), client)
+	v.log = logger.GetLoggerWithResource("test", nexus)
 
 	v.setUpdateDefaults(nexus)
 	latestMinor, err := update.GetLatestMinor()
@@ -291,6 +293,7 @@ func TestValidator_setNetworkingDefaults(t *testing.T) {
 			routeAvailable:   tt.routeAvailable,
 			ingressAvailable: tt.ingressAvailable,
 			ocp:              tt.ocp,
+			log:              logger.GetLoggerWithResource("test", tt.input),
 		}
 		got := tt.input.DeepCopy()
 		v.setNetworkingDefaults(got)
@@ -420,6 +423,7 @@ func TestValidator_validateNetworking(t *testing.T) {
 			routeAvailable:   tt.routeAvailable,
 			ingressAvailable: tt.ingressAvailable,
 			ocp:              tt.ocp,
+			log:              logger.GetLoggerWithResource("test", tt.input),
 		}
 		if err := v.validateNetworking(tt.input); (err != nil) != tt.wantError {
 			t.Errorf("%s\nWantError: %v\tError: %v", tt.name, tt.wantError, err)

--- a/pkg/controller/nexus/resource/validation/validation_test.go
+++ b/pkg/controller/nexus/resource/validation/validation_test.go
@@ -16,15 +16,16 @@ package validation
 
 import (
 	"fmt"
-	"github.com/m88i/nexus-operator/pkg/logger"
 	"reflect"
 	"testing"
 
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/update"
-	"github.com/m88i/nexus-operator/pkg/test"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/update"
+	"github.com/m88i/nexus-operator/pkg/logger"
+	"github.com/m88i/nexus-operator/pkg/test"
 )
 
 func TestNewValidator(t *testing.T) {

--- a/pkg/controller/nexus/server/log.go
+++ b/pkg/controller/nexus/server/log.go
@@ -1,0 +1,21 @@
+// Copyright 2020 Nexus Operator and/or its authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import "github.com/m88i/nexus-operator/pkg/logger"
+
+const defaultLogName = "server_operations"
+
+var log = logger.GetLogger(defaultLogName)

--- a/pkg/controller/nexus/server/nexus.go
+++ b/pkg/controller/nexus/server/nexus.go
@@ -41,8 +41,6 @@ const (
 	serverURLEnvKey = "NEXUS_SERVER_URL"
 )
 
-var log = logger.GetLogger("server_operations")
-
 func handleServerOperations(nexus *v1alpha1.Nexus, client client.Client, nexusAPIBuilder func(url, user, pass string) *nexusapi.Client) (v1alpha1.OperationsStatus, error) {
 	s := server{nexus: nexus, k8sclient: client, status: &v1alpha1.OperationsStatus{}}
 	if nexus.Spec.GenerateRandomAdminPassword {
@@ -73,6 +71,8 @@ func handleServerOperations(nexus *v1alpha1.Nexus, client client.Client, nexusAP
 
 // HandleServerOperations makes all required operations in the Nexus server side, such as creating the operator user
 func HandleServerOperations(nexus *v1alpha1.Nexus, client client.Client) (v1alpha1.OperationsStatus, error) {
+	log = logger.GetLoggerWithResource(defaultLogName, nexus)
+	defer func() { log = logger.GetLogger(defaultLogName) }()
 	return handleServerOperations(nexus, client, func(url, user, pass string) *nexusapi.Client {
 		return nexusapi.NewClient(url).WithCredentials(user, pass).Build()
 	})
@@ -99,6 +99,6 @@ func (s *server) isServerReady() bool {
 		return true
 	}
 	s.status.ServerReady = false
-	s.status.Reason = "Server does not have enough availble replicas"
+	s.status.Reason = "Server does not have enough available replicas"
 	return false
 }

--- a/pkg/controller/nexus/server/nexus.go
+++ b/pkg/controller/nexus/server/nexus.go
@@ -20,11 +20,12 @@ import (
 	"os"
 
 	nexusapi "github.com/m88i/aicura/nexus"
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/logger"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/logger"
 )
 
 type server struct {

--- a/pkg/controller/nexus/server/nexus_test.go
+++ b/pkg/controller/nexus/server/nexus_test.go
@@ -18,10 +18,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/m88i/aicura/nexus"
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
-	"github.com/m88i/nexus-operator/pkg/test"
 	"github.com/stretchr/testify/assert"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +26,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/m88i/aicura/nexus"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/controller/nexus/resource/meta"
+	"github.com/m88i/nexus-operator/pkg/test"
 )
 
 // createNewServerAndKubeCli creates a new fake server and kubernetes fake client to be used in tests for this package;

--- a/pkg/controller/nexus/server/users.go
+++ b/pkg/controller/nexus/server/users.go
@@ -106,7 +106,7 @@ func (u *userOperation) createOperatorUserIfNotExists() (*nexus.User, error) {
 func (u *userOperation) storeOperatorUserCredentials(user *nexus.User) error {
 	secret := &corev1.Secret{}
 	log.Debug("Attempt to store operator user credentials into Secret")
-	if err := framework.Fetch(u.k8sclient, framework.Key(u.nexus), secret, "Secret"); err != nil {
+	if err := framework.Fetch(u.k8sclient, framework.Key(u.nexus), secret, framework.SecretKind); err != nil {
 		return err
 	}
 	if secret.StringData == nil {

--- a/pkg/controller/nexus/server/users.go
+++ b/pkg/controller/nexus/server/users.go
@@ -19,8 +19,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/m88i/aicura/nexus"
-	"github.com/m88i/nexus-operator/pkg/framework"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/m88i/nexus-operator/pkg/framework"
 )
 
 const (

--- a/pkg/controller/nexus/server/users.go
+++ b/pkg/controller/nexus/server/users.go
@@ -70,9 +70,9 @@ func (u *userOperation) EnsureOperatorUser() error {
 }
 
 func (u *userOperation) createOperatorUserIfNotExists() (*nexus.User, error) {
-	// TODO: open an issue to handle access to a custom admin credentials to be used by the operator
+	// TODO: handle access to a custom admin credentials to be used by the operator
 	u.nexuscli.SetCredentials(defaultAdminUsername, defaultAdminPassword)
-	log.Debug("Attempt to create operator user. Cheking if it already exists.")
+	log.Debug("Attempt to create operator user. Checking if it already exists.")
 	user, err := u.nexuscli.UserService.GetUserByID(operatorUsername)
 	if err != nil {
 		if nexus.IsAuthenticationError(err) {
@@ -106,7 +106,7 @@ func (u *userOperation) createOperatorUserIfNotExists() (*nexus.User, error) {
 func (u *userOperation) storeOperatorUserCredentials(user *nexus.User) error {
 	secret := &corev1.Secret{}
 	log.Debug("Attempt to store operator user credentials into Secret")
-	if err := framework.Fetch(u.k8sclient, framework.Key(u.nexus), secret); err != nil {
+	if err := framework.Fetch(u.k8sclient, framework.Key(u.nexus), secret, "Secret"); err != nil {
 		return err
 	}
 	if secret.StringData == nil {
@@ -114,7 +114,7 @@ func (u *userOperation) storeOperatorUserCredentials(user *nexus.User) error {
 	}
 	secret.StringData[SecretKeyPassword] = user.Password
 	secret.StringData[SecretKeyUsername] = user.UserID
-	log.Debug("Updating secret with user credentials")
+	log.Debug("Updating Secret with user credentials")
 	if err := u.k8sclient.Update(context.TODO(), secret); err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func (u *userOperation) storeOperatorUserCredentials(user *nexus.User) error {
 
 func (u *userOperation) getOperatorUserCredentials() (user, password string, err error) {
 	secret := &corev1.Secret{}
-	if err := framework.Fetch(u.k8sclient, framework.Key(u.nexus), secret); err != nil {
+	if err := framework.Fetch(u.k8sclient, framework.Key(u.nexus), secret, framework.SecretKind); err != nil {
 		return "", "", err
 	}
 	return string(secret.Data[SecretKeyUsername]), string(secret.Data[SecretKeyPassword]), nil

--- a/pkg/controller/nexus/update/events.go
+++ b/pkg/controller/nexus/update/events.go
@@ -15,10 +15,11 @@
 package update
 
 import (
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/cluster/kubernetes"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/cluster/kubernetes"
 )
 
 const (

--- a/pkg/controller/nexus/update/events_test.go
+++ b/pkg/controller/nexus/update/events_test.go
@@ -19,11 +19,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/test"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/test"
 )
 
 func TestCreateUpdateSuccessEvent(t *testing.T) {

--- a/pkg/controller/nexus/update/log.go
+++ b/pkg/controller/nexus/update/log.go
@@ -12,8 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package resource
+package update
 
 import "github.com/m88i/nexus-operator/pkg/logger"
 
-var log = logger.GetLogger("resources_management")
+const (
+	defaultLogName = "update"
+	monitorLogName = "update_monitor"
+)
+
+var log = logger.GetLogger(defaultLogName)

--- a/pkg/controller/nexus/update/monitor.go
+++ b/pkg/controller/nexus/update/monitor.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/logger"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,6 +54,9 @@ func HandleUpdate(nexus *v1alpha1.Nexus, deployed, required *appsv1.Deployment, 
 		}
 		return nil
 	}
+
+	log = logger.GetLoggerWithResource(monitorLogName, nexus)
+	defer func() { log = logger.GetLogger(defaultLogName) }()
 
 	// it's important to check if this is a new update before checking ongoing updates because
 	// if this is a new update, the one that was happening before no longer matters
@@ -124,7 +128,7 @@ func isNewUpdate(deployed, required *appsv1.Deployment) (updating bool, previous
 
 	updating, err := HigherVersion(requiredImageParts[1], deployedImageParts[1])
 	if err != nil {
-		log.Warnf("Unable to check if the required deployment (%s) is an update when comparing to the deployed one: %v", required.Name, err)
+		log.Warnf("Unable to check if the required Deployment (%s) is an update when comparing to the deployed one: %v", required.Name, err)
 		return
 	}
 	previousTag = deployedImageParts[1]

--- a/pkg/controller/nexus/update/monitor.go
+++ b/pkg/controller/nexus/update/monitor.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/logger"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/logger"
 )
 
 const (

--- a/pkg/controller/nexus/update/monitor_test.go
+++ b/pkg/controller/nexus/update/monitor_test.go
@@ -18,12 +18,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/test"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/test"
 )
 
 func TestMonitorUpdate(t *testing.T) {

--- a/pkg/controller/nexus/update/tags.go
+++ b/pkg/controller/nexus/update/tags.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/heroku/docker-registry-client/registry"
-	"github.com/m88i/nexus-operator/pkg/logger"
 )
 
 const (
@@ -40,7 +39,6 @@ var (
 	lastQuery    time.Time
 	lastErr      time.Time
 	latestMicros = make(map[int]string)
-	log          = logger.GetLogger("update")
 )
 
 // HigherVersion checks if thisTag is of a higher version than otherTag

--- a/pkg/framework/controller_watcher_test.go
+++ b/pkg/framework/controller_watcher_test.go
@@ -18,14 +18,14 @@ import (
 	"testing"
 
 	routev1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
 	"github.com/m88i/nexus-operator/pkg/test"
-	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var requiredObjects = []WatchedObjects{

--- a/pkg/framework/fetcher.go
+++ b/pkg/framework/fetcher.go
@@ -16,11 +16,13 @@ package framework
 
 import (
 	ctx "context"
+
 	"github.com/RHsyseng/operator-utils/pkg/resource"
-	"github.com/m88i/nexus-operator/pkg/logger"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/m88i/nexus-operator/pkg/logger"
 )
 
 func Fetch(client client.Client, key types.NamespacedName, instance resource.KubernetesResource, kind string) error {

--- a/pkg/framework/fetcher.go
+++ b/pkg/framework/fetcher.go
@@ -16,18 +16,19 @@ package framework
 
 import (
 	ctx "context"
-
 	"github.com/RHsyseng/operator-utils/pkg/resource"
+	"github.com/m88i/nexus-operator/pkg/logger"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func Fetch(client client.Client, key types.NamespacedName, instance resource.KubernetesResource) error {
-	log.Debugf("Attempting to fetch deployed %s (%s)", instance.GetObjectKind(), key.Name)
+func Fetch(client client.Client, key types.NamespacedName, instance resource.KubernetesResource, kind string) error {
+	log := logger.GetLoggerWithNamespacedName("resource_fetcher", key)
+	log.Debugf("Attempting to fetch deployed %s", kind)
 	if err := client.Get(ctx.TODO(), key, instance); err != nil {
 		if errors.IsNotFound(err) {
-			log.Debugf("There is no deployed %s (%s)", instance.GetObjectKind(), key.Name)
+			log.Debugf("There is no deployed %s", kind)
 		}
 		return err
 	}

--- a/pkg/framework/fetcher_test.go
+++ b/pkg/framework/fetcher_test.go
@@ -17,12 +17,12 @@ package framework
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/m88i/nexus-operator/pkg/test"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFetch(t *testing.T) {

--- a/pkg/framework/fetcher_test.go
+++ b/pkg/framework/fetcher_test.go
@@ -28,14 +28,14 @@ import (
 func TestFetch(t *testing.T) {
 	deployment := &appsv1.Deployment{ObjectMeta: v1.ObjectMeta{Name: "deployment", Namespace: t.Name()}}
 	cli := test.NewFakeClientBuilder(deployment).Build()
-	err := Fetch(cli, Key(deployment), deployment)
+	err := Fetch(cli, Key(deployment), deployment, DeploymentKind)
 	assert.NoError(t, err)
 }
 
 func TestNotFoundFetch(t *testing.T) {
 	deployment := &appsv1.Deployment{ObjectMeta: v1.ObjectMeta{Name: "deployment", Namespace: t.Name()}}
 	cli := test.NewFakeClientBuilder().Build()
-	err := Fetch(cli, Key(deployment), deployment)
+	err := Fetch(cli, Key(deployment), deployment, DeploymentKind)
 	assert.Error(t, err)
 	assert.True(t, errors.IsNotFound(err))
 }

--- a/pkg/framework/kinds.go
+++ b/pkg/framework/kinds.go
@@ -1,0 +1,25 @@
+// Copyright 2020 Nexus Operator and/or its authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+const (
+	DeploymentKind = "Deployment"
+	IngressKind    = "Ingress"
+	PVCKind        = "Persistent Volume Claim"
+	RouteKind      = "Route"
+	SecretKind     = "Secret"
+	ServiceKind    = "Service"
+	SvcAccountKind = "Service Account"
+)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -15,18 +15,19 @@
 package logger
 
 import (
-	"github.com/RHsyseng/operator-utils/pkg/resource"
 	"io"
-	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"time"
 
+	"github.com/RHsyseng/operator-utils/pkg/resource"
 	"github.com/go-logr/logr"
-	"github.com/m88i/nexus-operator/pkg/util"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/m88i/nexus-operator/pkg/util"
 )
 
 var (

--- a/pkg/test/client.go
+++ b/pkg/test/client.go
@@ -18,8 +18,6 @@ import (
 	"context"
 
 	openapi_v2 "github.com/googleapis/gnostic/OpenAPIv2"
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/util"
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +30,9 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/util"
 )
 
 const (

--- a/pkg/test/client_test.go
+++ b/pkg/test/client_test.go
@@ -21,14 +21,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
-	"github.com/m88i/nexus-operator/pkg/cluster/kubernetes"
-	"github.com/m88i/nexus-operator/pkg/cluster/openshift"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/m88i/nexus-operator/pkg/apis/apps/v1alpha1"
+	"github.com/m88i/nexus-operator/pkg/cluster/kubernetes"
+	"github.com/m88i/nexus-operator/pkg/cluster/openshift"
 )
 
 const testErrorMsg = "test"


### PR DESCRIPTION
As the operator moves towards being cluster-scoped it's important that
users are able to quickly identify context from logs and can tell
exactly which Nexus CR is the subject of logs. To that effect this
change adds the "namespace" and "resource name" fields to structured
logging when applicable.

Additionally, standard output is now the default log output and sync
operations were removed as they're not necessary due to stdout's
unbuffered nature.

Fix #143

Signed-off-by: Lucas Caparelli <lucas.caparelli112@gmail.com>