### PR TITLE
Removing resource limits from manager Deployment

### DIFF
--- a/bundle/manifests/nexus-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/nexus-operator.clusterserviceversion.yaml
@@ -225,9 +225,6 @@ spec:
                 image: quay.io/m88i/nexus-operator:0.4.0
                 name: manager
                 resources:
-                  limits:
-                    cpu: 100m
-                    memory: 30Mi
                   requests:
                     cpu: 100m
                     memory: 20Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,9 +30,6 @@ spec:
         image: controller:latest
         name: manager
         resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/nexus-operator.yaml
+++ b/nexus-operator.yaml
@@ -608,9 +608,6 @@ spec:
         image: quay.io/m88i/nexus-operator:0.4.0
         name: manager
         resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

This will fix OpenShift 4.x deployments, where resources are hungry. Also, we should not set limits. That's up to users.