### PR TITLE
Add `conifigMap` to openshift required `SCC`s.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ $ oc apply -f examples/scc-volatile.yaml
 ```
 
 > **Note**: you must choose one or the other, applying both will result in using the one applied last.
+> **Note**: These have changed with the introduction of Nexus Operator version 0.6.0 to include `configMap` volumes.
 
 Once the SCC has been created, run:
 

--- a/examples/scc-persistent.yaml
+++ b/examples/scc-persistent.yaml
@@ -18,5 +18,6 @@ supplementalGroups:
       min: 200
   type: MustRunAs
 volumes:
+  - configMap
   - persistentVolumeClaim
   - secret

--- a/examples/scc-volatile.yaml
+++ b/examples/scc-volatile.yaml
@@ -18,4 +18,5 @@ supplementalGroups:
       min: 200
   type: MustRunAs
 volumes:
+  - configMap
   - secret


### PR DESCRIPTION
A change introduced in 0.6.0 requires we add `configMap` to the list of allowed volume types in the example `SCC`s